### PR TITLE
#3 [feature] Set DataStore, Create TokenDataStore

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,4 +92,13 @@ dependencies {
 
     // Login - Kakao
     implementation "com.kakao.sdk:v2-user:$kakao_version"
+
+    // Coroutine
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
+
+    // Jetpack DataStore
+    // Preferences DataStore (SharedPreferences like APIs)
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
+    implementation("androidx.datastore:datastore-preferences-core:1.0.0")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <application
         android:name="com.mate.baedalmate.BaedalMateApplication"
+        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/mate/baedalmate/common/extension/DataStoreExtension.kt
+++ b/app/src/main/java/com/mate/baedalmate/common/extension/DataStoreExtension.kt
@@ -1,0 +1,36 @@
+package com.mate.baedalmate.common.extension
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+
+suspend fun <T : Any> DataStore<Preferences>.readValue(
+    key: Preferences.Key<T>,
+    defaultValue: T?=null,
+): T? {
+    return data.catch { recoverOrThrow(it) }.map { it[key] }.firstOrNull() ?: defaultValue
+}
+
+suspend fun <T : Any> DataStore<Preferences>.storeValue(key: Preferences.Key<T>, value: T?) {
+    edit { preferences ->
+        if (value == null) {
+            preferences.remove(key)
+        } else {
+            preferences[key] = value
+        }
+    }
+}
+
+suspend fun FlowCollector<Preferences>.recoverOrThrow(throwable: Throwable) {
+    if (throwable is IOException) {
+        emit(emptyPreferences())
+    } else {
+        throw throwable
+    }
+}

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/member/MemberApiService.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/member/MemberApiService.kt
@@ -5,6 +5,6 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface MemberApiService {
-    @POST("/auth/kakao")
+    @POST("/login/oauth2/kakao")
     suspend fun requestLoginKakao(@Body data: MemberOAuthRequest): Response<MemberOAuthResponse>
 }

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/member/MemberRequest.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/member/MemberRequest.kt
@@ -3,6 +3,6 @@ package com.mate.baedalmate.data.datasource.remote.member
 import com.google.gson.annotations.SerializedName
 
 data class MemberOAuthRequest(
-    @SerializedName("kakao_access_token")
-    val kakao_access_token: String
+    @SerializedName("kakaoAccessToken")
+    val kakaoAccessToken: String
 )

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/member/MemberResponse.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/member/MemberResponse.kt
@@ -3,8 +3,8 @@ package com.mate.baedalmate.data.datasource.remote.member
 import com.google.gson.annotations.SerializedName
 
 data class MemberOAuthResponse(
-    @SerializedName("refresh_token")
-    val refresh_token: String,
-    @SerializedName("access_token")
-    val access_token: String
+    @SerializedName("accessToken")
+    val accessToken: String,
+    @SerializedName("refreshToken")
+    val refreshToken: String,
 )

--- a/app/src/main/java/com/mate/baedalmate/data/di/DataStoreModule.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/di/DataStoreModule.kt
@@ -1,0 +1,40 @@
+package com.mate.baedalmate.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.mate.baedalmate.data.repository.TokenPreferencesRepositoryImpl
+import com.mate.baedalmate.domain.repository.TokenPreferencesRepository
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private const val TOKEN_PREFERENCES = "token_preferences"
+
+val Context.tokenDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = TOKEN_PREFERENCES
+)
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataStoreModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTokenPreferencesRepository(
+        tokenPreferencesRepositoryImpl: TokenPreferencesRepositoryImpl
+    ): TokenPreferencesRepository
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideTokenDataStorePreferences(@ApplicationContext applicationContext: Context) : DataStore<Preferences> {
+            return applicationContext.tokenDataStore
+        }
+    }
+}

--- a/app/src/main/java/com/mate/baedalmate/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/di/NetworkModule.kt
@@ -16,7 +16,7 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
-    private const val BASE_URL = "" // TODO : Base URL 설정 필요
+    private const val BASE_URL = "http://3.35.27.107:8080"
 
     @Singleton
     @Provides
@@ -28,7 +28,7 @@ object NetworkModule {
                 val accessToken = "" // TODO : Access Token 설정 필요
                 val request = chain.request()
                 // Header에 AccessToken을 삽입하지 않는 대상
-                if (request.url.encodedPath.equals("/auth/kakao", true)
+                if (request.url.encodedPath.equals("/login/oauth2/kakao", true)
                 ) {
                     chain.proceed(request)
                 } else {
@@ -55,7 +55,10 @@ object NetworkModule {
 
     @Singleton
     @Provides
-    fun provideRetrofit(okHttpClient: OkHttpClient, gsonConverterFactory: GsonConverterFactory): Retrofit {
+    fun provideRetrofit(
+        okHttpClient: OkHttpClient,
+        gsonConverterFactory: GsonConverterFactory
+    ): Retrofit {
         return Retrofit.Builder()
             .baseUrl(BASE_URL)
             .addConverterFactory(ScalarsConverterFactory.create())

--- a/app/src/main/java/com/mate/baedalmate/data/repository/TokenPreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/repository/TokenPreferencesRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package com.mate.baedalmate.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.mate.baedalmate.common.extension.readValue
+import com.mate.baedalmate.common.extension.storeValue
+import com.mate.baedalmate.data.datasource.remote.member.MemberOAuthResponse
+import com.mate.baedalmate.domain.repository.TokenPreferencesRepository
+import javax.inject.Inject
+
+class TokenPreferencesRepositoryImpl @Inject constructor(private val tokenDataStorePreferences: DataStore<Preferences>) :
+    TokenPreferencesRepository {
+    override suspend fun setKakaoAccessToken(kakaoAccessToken: String) {
+        tokenDataStorePreferences.storeValue(kakaoAccessTokenKey, kakaoAccessToken)
+    }
+
+    override suspend fun getKakaoAccessToken(): String =
+        tokenDataStorePreferences.readValue(kakaoAccessTokenKey) ?: ""
+
+    override suspend fun setOAuthToken(memberOAuthResponse: MemberOAuthResponse) {
+        tokenDataStorePreferences.storeValue(accessTokenKey, memberOAuthResponse.accessToken)
+        tokenDataStorePreferences.storeValue(refreshTokenKey, memberOAuthResponse.refreshToken)
+    }
+
+    override suspend fun getOAuthToken(): MemberOAuthResponse {
+        return MemberOAuthResponse(
+            tokenDataStorePreferences.readValue(accessTokenKey) ?: "",
+            tokenDataStorePreferences.readValue(refreshTokenKey) ?: ""
+        )
+    }
+
+    private companion object {
+        val kakaoAccessTokenKey = stringPreferencesKey("kakaoAccessToken")
+        val accessTokenKey = stringPreferencesKey("accessToken")
+        val refreshTokenKey = stringPreferencesKey("refreshToken")
+    }
+}

--- a/app/src/main/java/com/mate/baedalmate/domain/repository/TokenPreferencesRepository.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/repository/TokenPreferencesRepository.kt
@@ -1,0 +1,10 @@
+package com.mate.baedalmate.domain.repository
+
+import com.mate.baedalmate.data.datasource.remote.member.MemberOAuthResponse
+
+interface TokenPreferencesRepository {
+    suspend fun setKakaoAccessToken(kakaoAccessToken: String)
+    suspend fun getKakaoAccessToken(): String
+    suspend fun setOAuthToken(memberOAuthResponse: MemberOAuthResponse)
+    suspend fun getOAuthToken(): MemberOAuthResponse
+}

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/LoginFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/LoginFragment.kt
@@ -40,7 +40,8 @@ class LoginFragment : Fragment() {
             Log.e(ContentValues.TAG, "카카오 로그인 실패", error)
         } else if (token != null) {
             Log.i(ContentValues.TAG, "카카오 로그인 성공 ${token.accessToken}")
-            loginViewModel.requestLoginKakao(accessToken = token.accessToken)
+            loginViewModel.setKakaoAccessToken(token.accessToken)
+            loginViewModel.requestLoginKakao()
         }
     }
 


### PR DESCRIPTION
## 내용 및 작업 사항
- Hilt를 이용하여 DataStore Dependency Injection 구현
- DataStoreExtension을 구현하여 Read및 Write 확장함수을 통해 DataStore 활용이 용이하도록 함
- 서버측의 카카오 로그인 구현 변경에 따른 코드 수정
- 기존에 카카오 AccessToken에 대한 기기 저장을 Presentation Layer에서 했던 것을 Domain Layer측에서 할 수 있도록 변경

## 참고
- #3 