### PR TITLE
#56 [bug] Add Missing Contents in Chatting

### DIFF
--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/chat/ChatResponse.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/chat/ChatResponse.kt
@@ -15,7 +15,9 @@ data class ChatRoomInfo(
     @SerializedName("image")
     val image: String,
     @SerializedName("lastMessage")
-    val lastMessage: MessageInfo
+    val lastMessage: MessageInfo,
+    @SerializedName("title")
+    val title: String
 )
 
 data class ChatRoomDetail(

--- a/app/src/main/java/com/mate/baedalmate/presentation/adapter/chat/ChatRoomListAdapter.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/adapter/chat/ChatRoomListAdapter.kt
@@ -55,9 +55,7 @@ class ChatRoomListAdapter(private val requestManager: RequestManager) :
             val lastMessageSendTimeString: String = info.lastMessage.sendDate
             var durationMinute = 0L
 
-            // binding.tvChatListTitle = info.lastMessage // TODO 현재 방 제목이 넘어오지 않음
-            binding.tvChatListTitle.text = info.lastMessage.sender // 임시로 보낸 사람으로 적용
-
+            binding.tvChatListTitle.text = info.title
             requestManager.load("http://3.35.27.107:8080/images/${info.image}")
                 .priority(Priority.HIGH)
                 .centerCrop()

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/chat/ChatFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
+import com.bumptech.glide.Priority
 import com.bumptech.glide.RequestManager
 import com.mate.baedalmate.R
 import com.mate.baedalmate.common.HideKeyBoardUtil
@@ -115,12 +116,10 @@ class ChatFragment : Fragment() {
                         with(createdTime) { "${this.year}년 ${this.monthValue + 1}월 ${this.dayOfMonth}일 ${this.hour}시 ${this.minute}분" }
                     binding.tvChatInfoContentsTitle.text = detail.recruit.title
 
-                    // TODO 서버에서의 이미지 전송 구현 후, 구현예정
-//                    glideRequestManager.load("http://3.35.27.107:8080/images/${detail}")
-//                        .thumbnail(0.1f)
-//                        .priority(Priority.HIGH)
-//                        .centerCrop()
-//                        .into(binding.imgChatInfo)
+                    glideRequestManager.load("http://3.35.27.107:8080/images/${detail.recruit.recruitImage}")
+                        .priority(Priority.HIGH)
+                        .centerCrop()
+                        .into(binding.imgChatInfo)
 
                     when (detail.recruit.criteria) {
                         RecruitFinishCriteria.TIME -> {
@@ -146,7 +145,7 @@ class ChatFragment : Fragment() {
                                 "${decimalFormat.format(detail.recruit.minPeople)}인"
                         }
                         RecruitFinishCriteria.PRICE -> {
-                            binding.tvChatInfoContentsCriterionTitle.text = "최소주문"
+                            binding.tvChatInfoContentsCriterionTitle.text = "목표금액"
                             binding.tvChatInfoContentsCriterionDetail.text =
                                 "${decimalFormat.format(detail.recruit.minPrice)}원"
                         }

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -131,7 +131,7 @@
                         android:paddingVertical="3dp"
                         android:singleLine="true"
                         android:textColor="@color/line_orange_FFA077"
-                        tools:text="최소주문" />
+                        tools:text="목표금액" />
 
                     <TextView
                         android:id="@+id/tv_chat_info_contents_criterion_detail"
@@ -155,6 +155,7 @@
                 android:stateListAnimator="@null"
                 android:text="@string/chat_info_action_change_menu"
                 android:textColor="@color/line_orange_FFA077"
+                android:visibility="invisible"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/fragment_chat_list.xml
+++ b/app/src/main/res/layout/fragment_chat_list.xml
@@ -38,6 +38,7 @@
             android:id="@+id/layout_chat_list_contents"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:background="@color/background_F7F8FA"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## 내용 및 작업 사항
- 채팅방 리스트에서 각 채팅방이 어떤 게시글을 의미하는 지 알 수 있는 게시글 제목이 나오지 않았던 점 서버에서 받아올 수 있도록 처리
- 채팅방 상세에서 상단에 해당 채팅방의 게시글의 대표이미지가 나오지 않았던 점 해결
- 이외 변경된 워딩에 대한 반영
## 참고
- resolved: #56