### PR TITLE
#91 [layout] Create Policy Fragment

### DIFF
--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/policy/PolicyFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/policy/PolicyFragment.kt
@@ -1,0 +1,71 @@
+package com.mate.baedalmate.presentation.fragment.policy
+
+import android.os.Bundle
+import android.view.KeyEvent
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebViewClient
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.mate.baedalmate.R
+import com.mate.baedalmate.common.autoCleared
+import com.mate.baedalmate.common.extension.setOnDebounceClickListener
+import com.mate.baedalmate.databinding.FragmentPolicyBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class PolicyFragment : Fragment() {
+    private var binding by autoCleared<FragmentPolicyBinding>()
+    private val args by navArgs<PolicyFragmentArgs>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentPolicyBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initActionbar()
+        showPolicy(args.informationType)
+        setWebViewBackClickListener()
+    }
+
+    private fun initActionbar() {
+        binding.btnPolicyActionBarBack.setOnDebounceClickListener {
+            findNavController().navigateUp()
+        }
+        binding.tvPolicyActionBarTitle.text =
+            if (args.informationType == "privacy") getString(R.string.policy_privacy)
+            else getString(R.string.policy_terms)
+    }
+
+    private fun showPolicy(informationType: String) {
+        with(binding.webviewPolicyContents) {
+            visibility = View.VISIBLE
+            apply {
+                webViewClient = WebViewClient()
+                settings.javaScriptEnabled = false
+            }
+            loadUrl("http://3.35.27.107:808/$informationType.html")
+        }
+        binding.webviewPolicyContents.visibility = View.VISIBLE
+    }
+
+    private fun setWebViewBackClickListener() {
+        binding.webviewPolicyContents.setOnKeyListener(
+            View.OnKeyListener { v, keyCode, event ->
+                if (event.action !== KeyEvent.ACTION_DOWN) return@OnKeyListener true
+                if (keyCode == KeyEvent.KEYCODE_BACK) {
+                    findNavController().navigateUp()
+                    return@OnKeyListener true
+                }
+                false
+            }
+        )
+    }
+}

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -54,4 +54,19 @@
             app:layout_constraintStart_toStartOf="@id/btn_login_kakao"
             app:layout_constraintTop_toTopOf="@id/btn_login_kakao" />
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <TextView
+        android:id="@+id/tv_login_use_guide_message"
+        style="@style/style_caption_bold_kor"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="18dp"
+        android:text="@string/login_policy_guide_message"
+        android:textColor="@color/gray_main_C4C4C4"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_login_method"
+        app:layout_constraintVertical_bias="1.0" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_policy.xml
+++ b/app/src/main/res/layout/fragment_policy.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.fragment.policy.PolicyFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_policy_action_bar"
+        android:layout_width="0dp"
+        android:layout_height="?actionBarSize"
+        android:elevation="24dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageButton
+            android:id="@+id/btn_policy_action_bar_back"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@android:color/transparent"
+            android:paddingHorizontal="18dp"
+            android:src="@drawable/ic_left_arrow"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/tv_policy_action_bar_title"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="ContentDescription" />
+
+        <TextView
+            android:id="@+id/tv_policy_action_bar_title"
+            style="@style/style_title1_kor"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/policy_terms"
+            android:textColor="@color/black_000000"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.5" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_policy_contents"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_policy_action_bar">
+
+        <WebView
+            android:id="@+id/webview_policy_contents"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="20dp" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph_login.xml
+++ b/app/src/main/res/navigation/nav_graph_login.xml
@@ -10,5 +10,24 @@
         android:name="com.mate.baedalmate.presentation.fragment.login.LoginFragment"
         android:label="fragment_login"
         tools:layout="@layout/fragment_login">
+
+        <action
+            android:id="@+id/action_loginFragment_to_policyFragment"
+            app:destination="@id/PolicyFragment"
+            app:enterAnim="@anim/slide_from_right"
+            app:exitAnim="@anim/slide_to_left"
+            app:popEnterAnim="@anim/slide_from_left"
+            app:popExitAnim="@anim/slide_to_right" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/PolicyFragment"
+        android:name="com.mate.baedalmate.presentation.fragment.policy.PolicyFragment"
+        android:label="fragment_policy"
+        tools:layout="@layout/fragment_policy">
+        <argument
+            android:name="informationType"
+            android:defaultValue="privacy"
+            app:argType="string" />
     </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,9 @@
 
     <!-- login -->
     <string name="login_select_method_kakao">카카오톡으로 시작하기</string>
+    <string name="login_policy_guide_message">가입 시 배달메이트의 이용약관및 개인정보취급방침에 동의하게 됩니다.</string>
+    <string name="policy_terms">이용약관</string>
+    <string name="policy_privacy">개인정보취급방침</string>
 
     <!-- Home -->
     <string name="home_top_title">님을 위한</string>


### PR DESCRIPTION
## 내용 및 작업사항
- 이용약관 및 개인정보처리방침을 웹뷰를 통해 보여주는 Fragment 생성 및 레이아웃 구현
- 로그인 Fragment에서 이용약관및 개인정보처리방침을 보여주는 Fragment로 이동할 수 있도록 레이아웃 수정 및 기능 구현
- 이용약관 및 개인정보처리방침을 각각에 따라서 navArgs를 통해 페이지를 다르게 연결할 수 있도록 구현
## 참고
- resolved: #91