### PR TITLE
[layout] Modify Post Fragment Layout 

### DIFF
--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostFragment.kt
@@ -65,7 +65,6 @@ class PostFragment : Fragment() {
         getPostDetailData()
         setBackClickListener()
         initContents()
-        setReportPostClickListener()
         observeCloseRecruitPostState()
         observeCancelRecruitPostState()
     }
@@ -195,7 +194,7 @@ class PostFragment : Fragment() {
 
     private fun initContentsUserInfo(recruitDetail: RecruitDetail) {
         with(binding) {
-            glideRequestManager.load(recruitDetail.profileImage)
+            glideRequestManager.load("http://3.35.27.107:8080/images/${recruitDetail.profileImage}")
                 .override(45.dp)
                 .thumbnail(0.1f)
                 .priority(Priority.HIGH)
@@ -331,19 +330,37 @@ class PostFragment : Fragment() {
                         initContentsUserInfo(recruitDetail)
                         initContentsPostInfo(recruitDetail)
                         setRecruitActionButton(recruitDetail)
+                        setReportPostClickListener(recruitDetail)
+                        setModifyPostClickListener(recruitDetail)
                     }
                 }
             }
         }
     }
 
-    private fun setReportPostClickListener() {
-        val span = SpannableString(binding.tvPostFrontUserReport.text)
-        span.setSpan(UnderlineSpan(), 0, span.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        binding.tvPostFrontUserReport.text = span
+    private fun setReportPostClickListener(recruitDetail: RecruitDetail) {
+        with(binding.tvPostFrontUserReport) {
+            val span = SpannableString(this.text)
+            span.setSpan(UnderlineSpan(), 0, span.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            this.text = span
 
-        binding.tvPostFrontUserReport.setOnDebounceClickListener {
-            findNavController().navigate(R.id.action_postFragment_to_reportPostFragment)
+            visibility = if (recruitDetail.host) View.GONE else View.VISIBLE
+            setOnDebounceClickListener {
+                findNavController().navigate(PostFragmentDirections.actionPostFragmentToReportPostFragment(
+                    postId = args.postId,
+                    postWriterName = recruitDetail.username,
+//                    postWriterUserId = recruitDetail.id // TODO API 수정시 수정
+                ))
+            }
+        }
+    }
+
+    private fun setModifyPostClickListener(recruitDetail: RecruitDetail) {
+        with(binding.tvPostFrontContentsDetailModify) {
+            visibility = if (recruitDetail.host) View.VISIBLE else View.GONE
+            setOnDebounceClickListener {
+                // TODO 수정하기 구현 추가시 Navigate 추가
+            }
         }
     }
 }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostMenuBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostMenuBottomSheetDialogFragment.kt
@@ -18,6 +18,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.mate.baedalmate.R
@@ -41,9 +42,12 @@ class PostMenuBottomSheetDialogFragment : BottomSheetDialogFragment() {
     private lateinit var loadingAlertDialog: AlertDialog
     private var addedMenuList = ListLiveData<MenuDto>()
     private var dishCount = 1
+    private lateinit var bottomSheetDialog: BottomSheetDialog
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        return BottomSheetDialog(requireContext(), R.style.BottomSheetDialogRadius)
+        bottomSheetDialog = BottomSheetDialog(requireContext(), R.style.BottomSheetDialogRadius)
+        bottomSheetDialog.behavior.skipCollapsed = true // Dialog가 길어지는 경우 Half_expand되는 경우 방지
+        return bottomSheetDialog
     }
 
     override fun onCreateView(
@@ -217,6 +221,8 @@ class PostMenuBottomSheetDialogFragment : BottomSheetDialogFragment() {
                 writeFourthMenuListAdapter.notifyDataSetChanged()
                 binding.layoutPostMenuAdded.visibility = View.VISIBLE
                 binding.btnPostFrontContentsParticipate.isEnabled = true
+
+                bottomSheetDialog.behavior.state = BottomSheetBehavior.STATE_EXPANDED // HALF EXPAND를 false 처리했음에도 처음에 동적으로 크기가 변하는 경우 절반만 보여지는 상태에 의해 해결을 위해 추가
             } else {
                 binding.layoutPostMenuAdded.visibility = View.GONE
                 binding.btnPostFrontContentsParticipate.isEnabled = false

--- a/app/src/main/res/layout/fragment_post.xml
+++ b/app/src/main/res/layout/fragment_post.xml
@@ -222,12 +222,14 @@
                             android:layout_marginTop="7dp"
                             android:text="@string/report"
                             android:textColor="@color/gray_dark_666666"
+                            android:visibility="visible"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintHorizontal_bias="1.0"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toBottomOf="@id/tv_post_front_user_dormitory"
-                            app:layout_constraintVertical_bias="0.0" />
+                            app:layout_constraintVertical_bias="0.0"
+                            tools:visibility="visible" />
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout
@@ -448,17 +450,33 @@
                             <TextView
                                 android:id="@+id/tv_post_front_contents_detail_title"
                                 style="@style/style_title2_kor"
-                                android:layout_width="wrap_content"
+                                android:layout_width="0dp"
                                 android:layout_height="wrap_content"
                                 android:layout_marginTop="15dp"
+                                android:singleLine="true"
                                 android:text="@string/post_detail_title"
                                 android:textColor="@color/main_FB5F1C"
                                 app:layout_constraintBottom_toBottomOf="parent"
-                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintEnd_toStartOf="@id/tv_post_front_contents_detail_modify"
                                 app:layout_constraintHorizontal_bias="0.0"
                                 app:layout_constraintStart_toStartOf="parent"
                                 app:layout_constraintTop_toTopOf="parent"
                                 app:layout_constraintVertical_bias="0.0" />
+
+                            <TextView
+                                android:id="@+id/tv_post_front_contents_detail_modify"
+                                style="@style/style_body2_kor"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/post_modify"
+                                android:textColor="@color/gray_dark_666666"
+                                android:visibility="gone"
+                                app:layout_constraintBottom_toBottomOf="@id/tv_post_front_contents_detail_title"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintHorizontal_bias="1.0"
+                                app:layout_constraintTop_toTopOf="@id/tv_post_front_contents_detail_title"
+                                app:layout_constraintVertical_bias="0.0"
+                                tools:visibility="visible" />
 
                             <TextView
                                 android:id="@+id/tv_post_front_contents_detail"

--- a/app/src/main/res/layout/fragment_post_delivery_fee_help.xml
+++ b/app/src/main/res/layout/fragment_post_delivery_fee_help.xml
@@ -220,6 +220,7 @@
                 android:paddingTop="10dp"
                 android:paddingBottom="13dp"
                 android:text="@string/confirm"
+                android:background="@drawable/selector_btn_gray_line_white_radius_10_bottom"
                 android:textColor="@color/black_000000"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_post_menu_bottom_sheet_dialog.xml
+++ b/app/src/main/res/layout/fragment_post_menu_bottom_sheet_dialog.xml
@@ -15,7 +15,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@drawable/background_white_radius_30_top"
-        android:paddingTop="15dp">
+        android:paddingTop="30dp">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_post_menu_input"

--- a/app/src/main/res/layout/fragment_report_post.xml
+++ b/app/src/main/res/layout/fragment_report_post.xml
@@ -233,7 +233,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="44dp"
-                    android:text="@{``}"
                     android:textColor="@color/main_FB5F1C"
                     tools:text="'캡스톤디자인' 님을 신고하고 싶으신가요?" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <string name="post_menu_add_description">추가할 메뉴와 금액을 작성하여, 모든 메뉴를 추가한 뒤 모집에 참여하세요</string>
     <string name="post_menu_added_title">현재 작성 메뉴</string>
     <string name="post_category_list_empty">현재 \'%s\' 에 대한\n모집글이 없어요</string>
+    <string name="post_modify"><u>모집글 수정하기</u></string>
 
     <!-- Write -->
     <string name="write_actionbar_title">상세 설정</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,12 +95,17 @@
     <string name="coupon_amount">쿠폰사용금액</string>
     <string name="post_map_title">배달 가게 위치</string>
     <string name="post_alert_message_close">해당 모집글이 마감처리 되었습니다</string>
+    <string name="post_alert_message_cancel">해당 모집글이 취소처리 되었습니다</string>
     <string name="post_alert_message_cancel_participate">참여 취소되었습니다.</string>
     <string name="post_menu_add_title">주문메뉴 추가</string>
     <string name="post_menu_add_description">추가할 메뉴와 금액을 작성하여, 모든 메뉴를 추가한 뒤 모집에 참여하세요</string>
     <string name="post_menu_added_title">현재 작성 메뉴</string>
     <string name="post_category_list_empty">현재 \'%s\' 에 대한\n모집글이 없어요</string>
     <string name="post_modify"><u>모집글 수정하기</u></string>
+    <string name="post_cancel_dialog_title">모집을 취소하시겠습니까?</string>
+    <string name="post_cancel_dialog_description">모집 취소 시, 지금까지 진행된 모집이 중단됩니다.</string>
+    <string name="post_close_dialog_title">모집을 마감하시겠습니까?</string>
+    <string name="post_close_dialog_description">모집 마감 시, 다른 참여자들이 해당 모집에 더 이상 참여할 수 없습니다.</string>
 
     <!-- Write -->
     <string name="write_actionbar_title">상세 설정</string>


### PR DESCRIPTION
## 내용 및 작업사항
- 신고하기 및 모집글 수정하기가 일반 유저와 주최자 여부에 따라 Visible 여부를 분기처리 할 수 있도록 처리
- 신고하기로 넘어갈 때, 모집글 정보와 주최자 정보를 넘길 수 있도록 수정
- 주최자가 모집 취소하기 및 모집 마감하기를 누루는 경우에 대한 AlertDialog 추가 및 확인 버튼 클릭시 서버에 반영한 뒤 반영이 완료된 경우에 모집글의 참여하기 표시가 마감된 모집글입니다로 변경될 수 있도록 구현
- PostFragment에서 주최자 썸네일이 보이지 않던 현상 해결
- 배달비 상세정보 dialog에서 확인버튼 클릭시 클릭여부를 알 수 있도록 background를 selector로 변경
- 모집 참여하기 BottomSheetDialog의 상단 Margin 값 수정
- 모집 참여하기 BottomSheetDialog에서 메뉴가 없는 상태에서 메뉴 최초 추가시, 긴 높이에 의해 자동으로 Dialog가 전부 올라가지 않고 일부가 잘려 드래그를 해야 전부 볼 수 있었던 현상 해결

## 참고
- #133 