### PR TITLE
#145 [layout] Create Closed Post Layout

### DIFF
--- a/app/src/main/java/com/mate/baedalmate/common/TimeChangerUtil.kt
+++ b/app/src/main/java/com/mate/baedalmate/common/TimeChangerUtil.kt
@@ -1,0 +1,44 @@
+package com.mate.baedalmate.common
+
+import android.content.Context
+import com.mate.baedalmate.R
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.Period
+
+object TimeChangerUtil {
+    fun getTimePassed(
+        context: Context,
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime
+    ): String {
+        var timePassed: String = ""
+        Period.between(startDateTime.toLocalDate(), endDateTime.toLocalDate())
+            .let { durationDate ->
+                if (durationDate.months < 1) {
+                    Duration.between(startDateTime, endDateTime).let { durationTime ->
+                        timePassed = when {
+                            durationTime.toDays() >= 1 -> "${durationTime.toDays()}${
+                                context.getString(R.string.time_unit_days)
+                            }"
+                            durationTime.toHours() >= 1 -> "${durationTime.toHours()}${
+                                context.getString(R.string.time_unit_hours)
+                            }"
+                            durationTime.toMinutes() >= 1 -> "${durationTime.toMinutes()}${
+                                context.getString(R.string.time_unit_minutes)
+                            }"
+                            else -> "${durationTime.seconds}${context.getString(R.string.time_unit_seconds)}"
+                        }
+                    }
+                } else {
+                    timePassed = when {
+                        durationDate.years >= 1 -> "${durationDate.years}${context.getString(R.string.time_unit_years)}"
+                        else -> {
+                            "${durationDate.months}${context.getString(R.string.time_unit_months)}"
+                        }
+                    }
+                }
+            }
+        return timePassed
+    }
+}

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/member/MemberResponse.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/member/MemberResponse.kt
@@ -10,8 +10,8 @@ data class MemberOAuthResponse(
 )
 
 data class UserInfoResponse(
-    @SerializedName("dormitory")
-    val dormitory: String,
+    @SerializedName("userDormitory")
+    val userDormitory: String,
     @SerializedName("nickname")
     val nickname: String,
     @SerializedName("profileImage")

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/recruit/RecruitListResponse.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/recruit/RecruitListResponse.kt
@@ -29,8 +29,8 @@ data class MainRecruitDto (
     val deadlineDate: String,
     @SerializedName("dormitory")
     val dormitory: String,
-    @SerializedName("id")
-    val id: Int,
+    @SerializedName("recruitId")
+    val recruitId: Int,
     @SerializedName("image")
     val image: String,
     @SerializedName("minPeople")
@@ -45,6 +45,8 @@ data class MainRecruitDto (
     val userScore: Float,
     @SerializedName("username")
     val username: String,
+    @SerializedName("active")
+    val active: Boolean
 )
 
 data class TagRecruitDto (
@@ -54,8 +56,8 @@ data class TagRecruitDto (
     val deadlineDate: String,
     @SerializedName("dormitory")
     val dormitory: String,
-    @SerializedName("id")
-    val id: Int,
+    @SerializedName("recruitId")
+    val recruitId: Int,
     @SerializedName("image")
     val image: String,
     @SerializedName("minPrice")
@@ -70,6 +72,8 @@ data class TagRecruitDto (
     val userScore: Float,
     @SerializedName("username")
     val username: String,
+    @SerializedName("active")
+    val active: Boolean,
 )
 
 data class CreateOrderResponse (

--- a/app/src/main/java/com/mate/baedalmate/domain/model/RecruitDetail.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/model/RecruitDetail.kt
@@ -1,6 +1,7 @@
 package com.mate.baedalmate.domain.model
 
 import com.google.gson.annotations.SerializedName
+import com.mate.baedalmate.data.datasource.remote.member.UserInfoResponse
 
 data class RecruitDetail(
     @SerializedName("active")
@@ -39,8 +40,12 @@ data class RecruitDetail(
     val shippingFeeDetail: List<ShippingFeeDto>,
     @SerializedName("title")
     val title: String,
-    @SerializedName("userDormitory")
-    val userDormitory: String,
-    @SerializedName("username")
-    val username: String
+    @SerializedName("userInfo")
+    val userInfo: UserInfoResponse,
+    @SerializedName("currentPrice")
+    val currentPrice: Int,
+    @SerializedName("minPrice")
+    val minPrice: Int,
+    @SerializedName("cancel")
+    val cancel: Boolean
 )

--- a/app/src/main/java/com/mate/baedalmate/domain/model/RecruitDto.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/model/RecruitDto.kt
@@ -15,8 +15,8 @@ data class RecruitDto (
     val deadlineDate: String,
     @SerializedName("dormitory")
     val dormitory: String,
-    @SerializedName("id")
-    val id: Int,
+    @SerializedName("recruitId")
+    val recruitId: Int,
     @SerializedName("image")
     val image: String,
     @SerializedName("minPeople")
@@ -28,5 +28,7 @@ data class RecruitDto (
     @SerializedName("title")
     val title: String,
     @SerializedName("userScore")
-    val userScore: Float
+    val userScore: Float,
+    @SerializedName("active")
+    val active: Boolean
 )

--- a/app/src/main/java/com/mate/baedalmate/presentation/adapter/HomeRecentPostAdapter.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/adapter/HomeRecentPostAdapter.kt
@@ -1,6 +1,7 @@
 package com.mate.baedalmate.presentation.adapter
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.findFragment
 import androidx.navigation.fragment.NavHostFragment
@@ -22,7 +23,7 @@ class HomeRecentPostAdapter(private val requestManager: RequestManager) :
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<MainRecruitDto>() {
             override fun areItemsTheSame(oldItem: MainRecruitDto, newItem: MainRecruitDto) =
-                oldItem.id == newItem.id
+                oldItem.recruitId == newItem.recruitId
 
             override fun areContentsTheSame(
                 oldItem: MainRecruitDto,
@@ -87,8 +88,24 @@ class HomeRecentPostAdapter(private val requestManager: RequestManager) :
                 root.setOnClickListener {
                     NavHostFragment.findNavController(binding.root.findFragment()).navigate(
                         HomeFragmentDirections.actionHomeFragmentToPostFragment(
-                        postId = post.id
+                        postId = post.recruitId
                     ))
+                }
+
+                setParticipateCloseLayout(post.active, this)
+            }
+        }
+
+        private fun setParticipateCloseLayout(isActive: Boolean, itemLayout: ItemHomeBottomPostRecentBinding) {
+            with(itemLayout) {
+                if (isActive) {
+                    layoutHomeBottomPostRecentParticipateClose.visibility = View.GONE
+                    imgHomeBottomPostRecentItemTopTime.visibility = View.VISIBLE
+                    tvHomeBottomPostRecentItemTopTime.visibility = View.VISIBLE
+                } else {
+                    layoutHomeBottomPostRecentParticipateClose.visibility = View.VISIBLE
+                    imgHomeBottomPostRecentItemTopTime.visibility = View.GONE
+                    tvHomeBottomPostRecentItemTopTime.visibility = View.GONE
                 }
             }
         }

--- a/app/src/main/java/com/mate/baedalmate/presentation/adapter/HomeRecommendPostAdapter.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/adapter/HomeRecommendPostAdapter.kt
@@ -1,6 +1,7 @@
 package com.mate.baedalmate.presentation.adapter
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.findFragment
 import androidx.navigation.fragment.NavHostFragment
@@ -22,7 +23,7 @@ class HomeRecommendPostAdapter(private val requestManager: RequestManager) :
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<MainRecruitDto>() {
             override fun areItemsTheSame(oldItem: MainRecruitDto, newItem: MainRecruitDto) =
-                oldItem.id == newItem.id
+                oldItem.recruitId == newItem.recruitId
 
             override fun areContentsTheSame(
                 oldItem: MainRecruitDto,
@@ -85,8 +86,24 @@ class HomeRecommendPostAdapter(private val requestManager: RequestManager) :
                 root.setOnClickListener {
                     NavHostFragment.findNavController(binding.root.findFragment()).navigate(
                         HomeFragmentDirections.actionHomeFragmentToPostFragment(
-                        postId = post.id
+                        postId = post.recruitId
                     ))
+                }
+                setParticipateCloseLayout(post.active, this)
+            }
+
+        }
+
+        private fun setParticipateCloseLayout(isActive: Boolean, itemLayout: ItemHomeBottomPostRecommendBinding) {
+            with(itemLayout) {
+                if (isActive) {
+                    layoutHomeBottomPostRecommendParticipateClose.visibility = View.GONE
+                    imgHomeBottomPostRecentItemTopTime.visibility = View.VISIBLE
+                    tvHomeBottomPostRecentItemTopTime.visibility = View.VISIBLE
+                } else {
+                    layoutHomeBottomPostRecommendParticipateClose.visibility = View.VISIBLE
+                    imgHomeBottomPostRecentItemTopTime.visibility = View.GONE
+                    tvHomeBottomPostRecentItemTopTime.visibility = View.GONE
                 }
             }
         }

--- a/app/src/main/java/com/mate/baedalmate/presentation/adapter/HomeTopPostAdapter.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/adapter/HomeTopPostAdapter.kt
@@ -32,7 +32,7 @@ class HomeTopPostAdapter(private val requestManager: RequestManager) :
                 oldItem: TagRecruitDto,
                 newItem: TagRecruitDto,
             ) =
-                oldItem.id == newItem.id
+                oldItem.recruitId == newItem.recruitId
 
             override fun areContentsTheSame(
                 oldItem: TagRecruitDto,
@@ -153,16 +153,23 @@ class HomeTopPostAdapter(private val requestManager: RequestManager) :
 
             binding.root.setOnClickListener {
                 findNavController(binding.root.findFragment()).navigate(HomeFragmentDirections.actionHomeFragmentToPostFragment(
-                    postId = post.id
+                    postId = post.recruitId
                 ))
             }
+
+            setParticipateCloseLayout(post.active, binding)
         }
     }
 
-    fun checkMoneyUnit(money: Int): Int {
-        if (money < 1000) return money
-        else {
-            return 0
+    fun setParticipateCloseLayout(isActive: Boolean, itemLayout: ItemHomeTopPostBinding) {
+        with(itemLayout) {
+            if (isActive) {
+                layoutHomeTopPostParticipateClose.visibility = View.GONE
+                tvHomeTopPostContentsInformationDescriptionTime.visibility = View.VISIBLE
+            } else {
+                layoutHomeTopPostParticipateClose.visibility = View.VISIBLE
+                tvHomeTopPostContentsInformationDescriptionTime.visibility = View.INVISIBLE
+            }
         }
     }
 }

--- a/app/src/main/java/com/mate/baedalmate/presentation/adapter/notification/NotificationAdapter.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/adapter/notification/NotificationAdapter.kt
@@ -17,7 +17,7 @@ class NotificationAdapter (private val requestManager: RequestManager) :
                 oldItem: RecruitDto,
                 newItem: RecruitDto,
             ) =
-                oldItem.id == newItem.id
+                oldItem.recruitId == newItem.recruitId
 
             override fun areContentsTheSame(
                 oldItem: RecruitDto,
@@ -66,7 +66,7 @@ class NotificationAdapter (private val requestManager: RequestManager) :
             val pos = adapterPosition
             if (pos != RecyclerView.NO_POSITION) {
                 binding.layoutNotificationItem.setOnClickListener {
-                    listener?.notificationClick(item.id, pos)
+                    listener?.notificationClick(item.recruitId, pos)
                 }
             }
 

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/home/HomeFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/home/HomeFragment.kt
@@ -99,7 +99,7 @@ class HomeFragment : Fragment() {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 memberViewModel.userInfo.observe(viewLifecycleOwner) { userInfo ->
                     userName = userInfo.nickname
-                    userDormitory = userInfo.dormitory
+                    userDormitory = userInfo.userDormitory
 
                     val span = SpannableString(userName)
                     setRoundTextView(span, "rounded", 0, span.length)
@@ -128,7 +128,7 @@ class HomeFragment : Fragment() {
             submitTagList.add(
                 TagRecruitDto(
                     "", "", "", 0, "", 0, "", 0, listOf(TagDto("")),
-                    0f, ""
+                    0f, "", true
                 )
             )
             homeTopPostAdapter.submitList(submitTagList)

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/mypage/MyPageFragment.kt
@@ -92,7 +92,7 @@ class MyPageFragment : Fragment() {
                 .into(binding.imgMyPageUserInfo)
 
             binding.tvMyPageUserInfoNickname.text = info.nickname
-            binding.tvMyPageUserInfoDormitory.text = "${info.dormitory}"
+            binding.tvMyPageUserInfoDormitory.text = "${info.userDormitory}"
             binding.tvMyPageUserInfoScore.text = info.score.toString()
         }
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryAllFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryAllFragment.kt
@@ -51,7 +51,7 @@ class PostCategoryAllFragment : Fragment() {
     private fun getRecruitList(sort: String = "deadlineDate") {
         recruitViewModel.requestCategoryRecruitList(
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryAsiaFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryAsiaFragment.kt
@@ -57,7 +57,7 @@ class PostCategoryAsiaFragment : Fragment() {
         recruitViewModel.requestCategoryRecruitList(
             categoryId = 10,
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryBunsikFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryBunsikFragment.kt
@@ -56,7 +56,7 @@ class PostCategoryBunsikFragment : Fragment() {
         recruitViewModel.requestCategoryRecruitList(
             categoryId = 6,
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryChickenFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryChickenFragment.kt
@@ -57,7 +57,7 @@ class PostCategoryChickenFragment : Fragment() {
         recruitViewModel.requestCategoryRecruitList(
             categoryId = 8,
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryChineseFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryChineseFragment.kt
@@ -57,7 +57,7 @@ class PostCategoryChineseFragment : Fragment() {
         recruitViewModel.requestCategoryRecruitList(
             categoryId = 2,
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryDessertFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryDessertFragment.kt
@@ -57,7 +57,7 @@ class PostCategoryDessertFragment : Fragment() {
         recruitViewModel.requestCategoryRecruitList(
             categoryId = 7,
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryFastfoodFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryFastfoodFragment.kt
@@ -57,7 +57,7 @@ class PostCategoryFastfoodFragment : Fragment() {
         recruitViewModel.requestCategoryRecruitList(
             categoryId = 5,
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryJapaneseFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryJapaneseFragment.kt
@@ -57,7 +57,7 @@ class PostCategoryJapaneseFragment : Fragment() {
         recruitViewModel.requestCategoryRecruitList(
             categoryId = 3,
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryKoreanFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryKoreanFragment.kt
@@ -57,7 +57,7 @@ class PostCategoryKoreanFragment : Fragment() {
         recruitViewModel.requestCategoryRecruitList(
             categoryId = 1,
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryPackedmealFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryPackedmealFragment.kt
@@ -57,7 +57,7 @@ class PostCategoryPackedmealFragment : Fragment() {
         recruitViewModel.requestCategoryRecruitList(
             categoryId = 11,
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryPizzaFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryPizzaFragment.kt
@@ -57,7 +57,7 @@ class PostCategoryPizzaFragment : Fragment() {
         recruitViewModel.requestCategoryRecruitList(
             categoryId = 9,
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryWesternFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostCategoryWesternFragment.kt
@@ -57,7 +57,7 @@ class PostCategoryWesternFragment : Fragment() {
         recruitViewModel.requestCategoryRecruitList(
             categoryId = 4,
             page = 0,
-            size = 25,
+            size = 10000,
             sort = sort
         )
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostFragment.kt
@@ -256,8 +256,8 @@ class PostFragment : Fragment() {
                 .into(imgPostFrontUser)
             displayUserScore(recruitDetail.score)
 
-            tvPostFrontUserName.text = recruitDetail.username
-            tvPostFrontUserDormitory.text = recruitDetail.userDormitory
+            tvPostFrontUserName.text = recruitDetail.userInfo.nickname
+            tvPostFrontUserDormitory.text = recruitDetail.userInfo.userDormitory
         }
     }
 
@@ -415,8 +415,8 @@ class PostFragment : Fragment() {
                 findNavController().navigate(
                     PostFragmentDirections.actionPostFragmentToReportPostFragment(
                         postId = args.postId,
-                        postWriterName = recruitDetail.username,
-//                    postWriterUserId = recruitDetail.id // TODO API 수정시 수정
+                        postWriterName = recruitDetail.userInfo.nickname,
+                        postWriterUserId = recruitDetail.userInfo.userId.toInt()
                     )
                 )
             }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/adapter/PostCategoryListAdapter.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/adapter/PostCategoryListAdapter.kt
@@ -200,7 +200,7 @@ class PostCategoryListAdapter(private val requestManager: RequestManager) :
                     )
                     imgPostCategoryList.imageTintList = ContextCompat.getColorStateList(
                         imgPostCategoryList.context,
-                        R.color.overray_black_B3212123
+                        R.color.overlay_black_B3212123
                     )
                     tvPostCategoryListParticipateClose.visibility = View.VISIBLE
                     tvPostCategoryListTitle.setTextColor(

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/adapter/PostCategoryListAdapter.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/adapter/PostCategoryListAdapter.kt
@@ -5,12 +5,16 @@ import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.StyleSpan
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Priority
 import com.bumptech.glide.RequestManager
+import com.mate.baedalmate.R
+import com.mate.baedalmate.common.TimeChangerUtil.getTimePassed
 import com.mate.baedalmate.domain.model.RecruitDto
 import com.mate.baedalmate.databinding.ItemPostCategoryListBinding
 import com.mate.baedalmate.domain.model.RecruitFinishCriteria
@@ -27,7 +31,7 @@ class PostCategoryListAdapter(private val requestManager: RequestManager) :
                 oldItem: RecruitDto,
                 newItem: RecruitDto,
             ) =
-                oldItem.id == newItem.id
+                oldItem.recruitId == newItem.recruitId
 
             override fun areContentsTheSame(
                 oldItem: RecruitDto,
@@ -82,8 +86,7 @@ class PostCategoryListAdapter(private val requestManager: RequestManager) :
 
             if (item.createDate.isNotEmpty()) {
                 val createTime = LocalDateTime.parse(createdTimeString, formatter)
-                val duration = Duration.between(createTime, currentTime).toMinutes()
-                durationMinuteCreated = duration.toString()
+                durationMinuteCreated = getTimePassed(binding.layoutPostCategoryList.context, createTime, currentTime)
             }
             if (item.deadlineDate.isNotEmpty()) {
                 val deadLineTime = LocalDateTime.parse(deadLineTimeString, formatter)
@@ -94,7 +97,7 @@ class PostCategoryListAdapter(private val requestManager: RequestManager) :
             val pos = adapterPosition
             if (pos != RecyclerView.NO_POSITION) {
                 binding.layoutPostCategoryList.setOnClickListener {
-                    listener?.postClick(item.id, pos)
+                    listener?.postClick(item.recruitId, pos)
                 }
             }
 
@@ -106,7 +109,7 @@ class PostCategoryListAdapter(private val requestManager: RequestManager) :
             binding.tvPostCategoryListTitle.text = item.title
             binding.tvPostCategoryListLocationStore.text = item.place
             binding.tvPostCategoryListLocationUser.text = item.dormitory
-            binding.tvPostCategoryListTimePassed.text = "${durationMinuteCreated}분 전"
+            binding.tvPostCategoryListTimePassed.text = durationMinuteCreated
             when (item.criteria) {
                 RecruitFinishCriteria.NUMBER -> {
                     val goalText = "${item.minPeople}인 모집 "
@@ -150,6 +153,89 @@ class PostCategoryListAdapter(private val requestManager: RequestManager) :
                         Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
                     )
                     binding.tvPostCategoryListContentsStateGoal.text = span
+                }
+            }
+
+            setParticipateCloseLayout(item.active, binding)
+        }
+
+        private fun setParticipateCloseLayout(
+            isActive: Boolean,
+            itemLayout: ItemPostCategoryListBinding
+        ) {
+            with(itemLayout) {
+                if (isActive) {
+                    layoutPostCategoryList.background = ContextCompat.getDrawable(
+                        layoutPostCategoryList.context,
+                        R.drawable.selector_post_category_list
+                    )
+                    imgPostCategoryList.imageTintList = null
+                    tvPostCategoryListParticipateClose.visibility = View.GONE
+                    tvPostCategoryListTitle.setTextColor(
+                        ContextCompat.getColor(
+                            tvPostCategoryListTitle.context,
+                            R.color.black_000000
+                        )
+                    )
+                    imgPostCategoryListLocationStore.imageTintList = null
+                    tvPostCategoryListLocationStore.setTextColor(
+                        ContextCompat.getColor(
+                            tvPostCategoryListTitle.context,
+                            R.color.black_000000
+                        )
+                    )
+                    imgPostCategoryListLocationUser.imageTintList = null
+                    tvPostCategoryListLocationUser.setTextColor(
+                        ContextCompat.getColor(
+                            tvPostCategoryListLocationUser.context,
+                            R.color.black_000000
+                        )
+                    )
+                    tvPostCategoryListContentsStateGoalTitle.backgroundTintList = null
+                    tvPostCategoryListContentsStateGoal.visibility = View.VISIBLE
+                } else {
+                    layoutPostCategoryList.background = ContextCompat.getDrawable(
+                        layoutPostCategoryList.context,
+                        R.color.gray_main_C4C4C4
+                    )
+                    imgPostCategoryList.imageTintList = ContextCompat.getColorStateList(
+                        imgPostCategoryList.context,
+                        R.color.overray_black_B3212123
+                    )
+                    tvPostCategoryListParticipateClose.visibility = View.VISIBLE
+                    tvPostCategoryListTitle.setTextColor(
+                        ContextCompat.getColor(
+                            tvPostCategoryListTitle.context,
+                            R.color.gray_dark_666666
+                        )
+                    )
+                    imgPostCategoryListLocationStore.imageTintList =
+                        ContextCompat.getColorStateList(
+                            imgPostCategoryListLocationStore.context,
+                            R.color.gray_dark_666666
+                        )
+                    tvPostCategoryListLocationStore.setTextColor(
+                        ContextCompat.getColor(
+                            tvPostCategoryListTitle.context,
+                            R.color.gray_dark_666666
+                        )
+                    )
+                    imgPostCategoryListLocationUser.imageTintList = ContextCompat.getColorStateList(
+                        imgPostCategoryListLocationUser.context,
+                        R.color.gray_dark_666666
+                    )
+                    tvPostCategoryListLocationUser.setTextColor(
+                        ContextCompat.getColor(
+                            tvPostCategoryListLocationUser.context,
+                            R.color.gray_dark_666666
+                        )
+                    )
+                    tvPostCategoryListContentsStateGoalTitle.backgroundTintList =
+                        ContextCompat.getColorStateList(
+                            tvPostCategoryListContentsStateGoalTitle.context,
+                            R.color.gray_line_EBEBEB
+                        )
+                    tvPostCategoryListContentsStateGoal.visibility = View.GONE
                 }
             }
         }

--- a/app/src/main/java/com/mate/baedalmate/presentation/viewmodel/RecruitViewModel.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/viewmodel/RecruitViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mate.baedalmate.common.Event
+import com.mate.baedalmate.data.datasource.remote.member.UserInfoResponse
 import com.mate.baedalmate.data.datasource.remote.recruit.CreateOrderRequest
 import com.mate.baedalmate.data.datasource.remote.recruit.CreateOrderResponse
 import com.mate.baedalmate.data.datasource.remote.recruit.DeleteOrderDto
@@ -103,8 +104,10 @@ class RecruitViewModel @Inject constructor(
             0,
             emptyList(),
             "",
-            "",
-            ""
+            UserInfoResponse("", "", "", 5f, 0L),
+            0,
+            0,
+            false
         )
     )
     val recruitPostDetail: LiveData<RecruitDetail> get() = _recruitPostDetail
@@ -114,7 +117,7 @@ class RecruitViewModel @Inject constructor(
             listOf(
                 MainRecruitDto(
                     "", 0, "", "", 0,
-                    "", 0, 0, "", 0, 0f, ""
+                    "", 0, 0, "", 0, 0f, "", true
                 )
             )
         )
@@ -126,7 +129,7 @@ class RecruitViewModel @Inject constructor(
             listOf(
                 MainRecruitDto(
                     "", 0, "", "", 0,
-                    "", 0, 0, "", 0, 0f, ""
+                    "", 0, 0, "", 0, 0f, "", true
                 )
             )
         )

--- a/app/src/main/res/layout/fragment_post_category_list.xml
+++ b/app/src/main/res/layout/fragment_post_category_list.xml
@@ -87,7 +87,6 @@
             android:id="@+id/vp_post_category_list_contents"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_marginBottom="?attr/actionBarSize"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_home_bottom_post_recent.xml
+++ b/app/src/main/res/layout/item_home_bottom_post_recent.xml
@@ -266,5 +266,37 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_home_bottom_post_recent_participate_close"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginEnd="15dp"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <com.google.android.material.imageview.ShapeableImageView
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:background="@color/overray_black_B3212123"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:shapeAppearanceOverlay="@style/radius10_ImageView" />
+
+            <TextView
+                style="@style/style_title1_kor"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/participate_close"
+                android:textColor="@color/white_FFFFFF"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="0.3" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_home_bottom_post_recent.xml
+++ b/app/src/main/res/layout/item_home_bottom_post_recent.xml
@@ -278,7 +278,7 @@
             <com.google.android.material.imageview.ShapeableImageView
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:background="@color/overray_black_B3212123"
+                android:background="@color/overlay_black_B3212123"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_home_bottom_post_recommend.xml
+++ b/app/src/main/res/layout/item_home_bottom_post_recommend.xml
@@ -34,6 +34,41 @@
                 app:shapeAppearanceOverlay="@style/radius10_ImageView" />
 
             <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_home_bottom_post_recommend_participate_close"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@id/img_home_bottom_post_recommend_item"
+                app:layout_constraintEnd_toEndOf="@id/img_home_bottom_post_recommend_item"
+                app:layout_constraintStart_toStartOf="@id/img_home_bottom_post_recommend_item"
+                app:layout_constraintTop_toTopOf="@id/img_home_bottom_post_recommend_item"
+                tools:visibility="visible">
+
+                <com.google.android.material.imageview.ShapeableImageView
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:background="@color/overray_black_B3212123"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:shapeAppearanceOverlay="@style/radius10_ImageView" />
+
+                <TextView
+                    style="@style/style_semi_title_kor"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/participate_close"
+                    android:textColor="@color/white_FFFFFF"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.5"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0.5" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/layout_home_bottom_post_recommend_item_info"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_home_bottom_post_recommend.xml
+++ b/app/src/main/res/layout/item_home_bottom_post_recommend.xml
@@ -47,7 +47,7 @@
                 <com.google.android.material.imageview.ShapeableImageView
                     android:layout_width="0dp"
                     android:layout_height="0dp"
-                    android:background="@color/overray_black_B3212123"
+                    android:background="@color/overlay_black_B3212123"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_home_top_post.xml
+++ b/app/src/main/res/layout/item_home_top_post.xml
@@ -351,5 +351,43 @@
                     app:layout_constraintVertical_bias="0.0" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_home_top_post_participate_close"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            android:layout_marginTop="6dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_home_top_post_tag"
+            app:layout_constraintVertical_bias="0.0"
+            tools:visibility="visible">
+
+            <com.google.android.material.imageview.ShapeableImageView
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:background="@color/overray_black_B3212123"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:shapeAppearanceOverlay="@style/radius10_ImageView" />
+
+            <TextView
+                style="@style/style_title2_kor"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/participate_close"
+                android:textColor="@color/white_FFFFFF"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.25"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="0.5" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_home_top_post.xml
+++ b/app/src/main/res/layout/item_home_top_post.xml
@@ -369,7 +369,7 @@
             <com.google.android.material.imageview.ShapeableImageView
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:background="@color/overray_black_B3212123"
+                android:background="@color/overlay_black_B3212123"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_post_category_list.xml
+++ b/app/src/main/res/layout/item_post_category_list.xml
@@ -12,9 +12,9 @@
             android:id="@+id/layout_post_category_list"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:background="@drawable/selector_post_category_list"
             android:paddingHorizontal="15dp"
             android:paddingVertical="18dp"
-            android:background="@drawable/selector_post_category_list"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -32,7 +32,22 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintVertical_bias="0.5"
-                app:shapeAppearanceOverlay="@style/roundImageView" />
+                app:shapeAppearanceOverlay="@style/roundImageView"
+                app:tintMode="src_atop"
+                tools:src="@drawable/img_category_packedmeal" />
+
+            <TextView
+                android:id="@+id/tv_post_category_list_participate_close"
+                style="@style/style_semi_title_kor"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/participate_close"
+                android:textColor="@color/white_FFFFFF"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@id/img_post_category_list"
+                app:layout_constraintEnd_toEndOf="@id/img_post_category_list"
+                app:layout_constraintStart_toStartOf="@id/img_post_category_list"
+                app:layout_constraintTop_toTopOf="@id/img_post_category_list" />
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/layout_post_category_list_contents"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,7 +7,7 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-
+ㅂ
     <color name="black_000000">#FF000000</color>
     <color name="white_FFFFFF">#FFFFFFFF</color>
     <color name="main_FB5F1C">#FFFB5F1C</color>
@@ -20,4 +20,5 @@
     <color name="line_orange_FFA077">#FFFFA077</color>
     <color name="fill_orange_FFF3F0">#FFFFF3F0</color>
     <color name="background_F7F8FA">#FFF7F8FA</color>
+    <color name="overray_black_B3212123">#B3212123</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -20,5 +20,5 @@
     <color name="line_orange_FFA077">#FFFFA077</color>
     <color name="fill_orange_FFF3F0">#FFFFF3F0</color>
     <color name="background_F7F8FA">#FFF7F8FA</color>
-    <color name="overray_black_B3212123">#B3212123</color>
+    <color name="overlay_black_B3212123">#B3212123</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,15 @@
     <string name="nickname">닉네임</string>
     <string name="save">저장하기</string>
     <string name="dialog_loading_wait_description">잠시만 기다려 주세요!</string>
+    <string name="participate_close">모집 완료</string>
+    <!-- Time Unit -->
+    <string name="time_unit_years">년 전</string>
+    <string name="time_unit_months">달 전</string>
+    <string name="time_unit_days">일 전</string>
+    <string name="time_unit_hours">시간 전</string>
+    <string name="time_unit_minutes">분 전</string>
+    <string name="time_unit_seconds">초 전</string>
+
     <!-- University -->
     <string name="university_seoultech">서울과기대</string>
 


### PR DESCRIPTION
## 내용 및 작업사항
- 모집글을 나타내는 HomeFragment에서의 아이템과, PostCategoryList에서의 아이템에 대해 모집 마감된 경우에 대한 레이아웃 추가
   - 모집 마감된 경우 기존의 아이템위에 Overlay를 씌운뒤 모집 완료 Textview가 나타나도록 설정
- 모집글이 마감되었는지 안되었는지 나타내는 Active를 서버에서 추가적으로 받아옴에 따라 일부 DTO 수정
   - 이외 누락된 요소 추가
   - 해당 변경으로 인해 영향받는 코드들에 대한 수정
- 모집글 리스트에서 각 모집글이 올린지 얼마나 지났는지를 보여주는 시간에 대해 `TimeChangerUtil`로 분리
   - 관련 String 추가
- 모집글 카테고리 리스트 Fragment에서 한번에 받아오는 size의 갯수 증가시킴

## 참고
- 추후 무한 스크롤을 통해 모집글 리스트를 받아올 수 있도록 수정해야함
- resolved: #145