### PR TITLE
#166 [bug] Fix HomeFragment Tag Post List Null error

### DIFF
--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/home/HomeFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/home/HomeFragment.kt
@@ -141,7 +141,8 @@ class HomeFragment : Fragment() {
         val editedTagPostList = mutableListOf<TagRecruitDto>()
         for(tagPost in tagPostList) {
             var currentPost = tagPost
-            currentPost.tags = currentPost.tags.subList(0, MAX_TAG_COUNT)
+            if (currentPost.tags.size >= MAX_TAG_COUNT)
+                currentPost.tags = currentPost.tags.subList(0, MAX_TAG_COUNT)
             editedTagPostList.add(currentPost)
         }
 


### PR DESCRIPTION
## 내용 및 작업사항
- 상단 태그와 함께 나타나는 글 리스트 표시과정중, 태그가 최대 태그 표시개수보다 적게 나와있는 경우 앱이 종료되는 버그
   - 태그 개수에 따라 subList할지 말지를 분기처리

## 참고
- resolved: #166