### PR TITLE
#168 [feature] Set Token Auto-Refresh

### DIFF
--- a/app/src/main/java/com/mate/baedalmate/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/di/NetworkModule.kt
@@ -1,6 +1,13 @@
 package com.mate.baedalmate.data.di
 
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.google.gson.GsonBuilder
 import com.mate.baedalmate.BaedalMateApplication
 import dagger.Module
 import dagger.Provides
@@ -14,7 +21,16 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import com.mate.baedalmate.BuildConfig
 import com.mate.baedalmate.common.extension.readValue
+import com.mate.baedalmate.common.extension.storeValue
+import io.sentry.Sentry
+import io.sentry.SentryLevel
 import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.Request
+import okhttp3.RequestBody
+import org.json.JSONException
+import org.json.JSONObject
+import java.lang.Exception
 import javax.inject.Singleton
 
 @Module
@@ -24,10 +40,20 @@ object NetworkModule {
 
     @Singleton
     @Provides
-    fun provideOkHttpClient() = if (BuildConfig.DEBUG) {
+    fun provideOkHttpClient(): OkHttpClient {
         val loggingInterceptor = HttpLoggingInterceptor()
         loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY)
-        OkHttpClient.Builder()
+        return OkHttpClient.Builder()
+            .addNetworkInterceptor { chain ->
+                val requestBuild = chain.request().newBuilder()
+                    .removeHeader("User-Agent") // otherwise addHeader not work.
+                    .addHeader(
+                        "User-Agent",
+                        "${Build.MODEL} BaedalMate/${BuildConfig.VERSION_NAME} (${BaedalMateApplication.applicationContext().packageName}; build:${BuildConfig.VERSION_CODE}; Android ${Build.VERSION.SDK_INT})"
+                    )
+                    .build()
+                chain.proceed(requestBuild)
+            }
             .addInterceptor { chain: Interceptor.Chain ->
                 val accessToken = runBlocking {
                     BaedalMateApplication.applicationContext().tokenDataStore.readValue(
@@ -36,9 +62,7 @@ object NetworkModule {
                 }
                 val request = chain.request()
                 // Header에 AccessToken을 삽입하지 않는 대상
-                if (request.url.encodedPath.equals("/login/oauth2/kakao", true) ||
-                    request.url.encodedPath.contains("/v2/local/search/keyword.json", true)
-                ) {
+                if (request.url.encodedPath.equals("/login/oauth2/kakao", true)) {
                     chain.proceed(request)
                 } else {
                     chain.proceed(
@@ -48,12 +72,108 @@ object NetworkModule {
                     )
                 }
             }
+            .addInterceptor { chain: Interceptor.Chain ->
+                val originalRequest = chain.request()
+                val originalResponse = chain.proceed(originalRequest)
+                val accessToken = runBlocking {
+                    BaedalMateApplication.applicationContext().tokenDataStore.readValue(
+                        stringPreferencesKey("accessToken")
+                    )
+                }
+                val refreshToken =
+                    runBlocking {
+                        BaedalMateApplication.applicationContext().tokenDataStore.readValue(
+                            stringPreferencesKey("refreshToken")
+                        )
+                    }
+                val emptyBody = RequestBody.create("application/json".toMediaTypeOrNull(), "")
+                when (originalResponse.code) {
+                    401 -> {
+                        val newRequest = Request.Builder()
+                            .url("${BASE_URL}/api/v1/refresh")
+                            .addHeader("Authorization", "Bearer $accessToken")
+                            .addHeader("Refresh-Token", "$refreshToken")
+                            .post(emptyBody)
+                            .build()
+                        var tokenRefreshResponse = chain.proceed(newRequest)
+                        when (tokenRefreshResponse.code) {
+                            200 or 403 -> {
+                                val rawResponseJson = tokenRefreshResponse.peekBody(2048).string()
+                                try {
+                                    val refreshedAccessToken =
+                                        JSONObject(rawResponseJson).getString("accessToken")
+                                    val refreshedRefreshToken =
+                                        JSONObject(rawResponseJson).getString("refreshToken")
+                                    runBlocking {
+                                        BaedalMateApplication.applicationContext().tokenDataStore.storeValue(
+                                            stringPreferencesKey("accessToken"),
+                                            refreshedAccessToken,
+                                        )
+                                        BaedalMateApplication.applicationContext().tokenDataStore.storeValue(
+                                            stringPreferencesKey("refreshToken"),
+                                            refreshedRefreshToken,
+                                        )
+                                    }
+                                    val newTokenOriginalRequest = chain.request().newBuilder()
+                                        .removeHeader("Authorization")
+                                        .addHeader("Authorization", "Bearer $refreshedAccessToken")
+                                        .build()
+                                    tokenRefreshResponse = chain.proceed(newTokenOriginalRequest)
+                                } catch (e: JSONException) {
+                                    e.printStackTrace()
+                                    Sentry.captureException(e)
+                                } catch (e: Exception) {
+                                    e.printStackTrace()
+                                    Sentry.captureException(e)
+                                }
+                            }
+                            in 400..401 -> {
+                                if (!originalRequest.url.encodedPath.equals("/api/v1/user", true)) {
+                                    val handler = Handler(Looper.getMainLooper())
+                                    handler.postDelayed(
+                                        Runnable {
+                                            Toast.makeText(
+                                                BaedalMateApplication.applicationContext(),
+                                                "다시 로그인 해주세요",
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                        },
+                                        0
+                                    )
+                                }
+                            }
+                            else -> {
+                                Log.e("Token Refresh Network Error", "$$tokenRefreshResponse")
+                                Sentry.captureMessage(
+                                    "Token Refresh Network Error: $tokenRefreshResponse",
+                                    SentryLevel.ERROR
+                                )
+                                val handler = Handler(Looper.getMainLooper())
+                                handler.postDelayed(
+                                    Runnable {
+                                        Toast.makeText(
+                                            BaedalMateApplication.applicationContext(),
+                                            "네트워크 연결이 불안정 합니다",
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+                                    },
+                                    0
+                                )
+                            }
+                        }
+                        tokenRefreshResponse
+                    }
+                    403 -> {
+                        originalResponse
+                    }
+                    else -> {
+                        originalResponse
+                    }
+                }
+            }
             .addInterceptor(loggingInterceptor)
             .readTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
             .connectTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
-            .build()
-    } else {
-        OkHttpClient.Builder()
             .build()
     }
 


### PR DESCRIPTION
## 내용
- DEBUG 모드에서만 Retrofit이 작동되도록 구현했던 코드부분 삭제
- AccessToken은 카카오 로그인 이외의 모든 API 요청시 사용하도록 구현
- API 요청하는 경우, AccessToken 만료시 자동으로 RefreshToken을 이용해 Token을 Refresh한 다음, Refresh된 AccessToken과 RefreshToken을 이용해 다시 API 요청을 보낼 수 있도록 구현
   - API 요청시 401 응답이 오는 경우, 기존 API 요청을 가로챈뒤 Token Refresh POST 요청을 먼저 보낸뒤 정상적인 200 응답에 대해 갱신된 AcessToken과 RefreshToken을 활용해 가로챘던 기존 API 요청을 다시 실행하도록 구현
   - 그럼에도 400과 401 요청이 오는 경우 토스트메시지를 보여주도록 구현
- 401, 403 요청 분기처리

## 참고
- resolved: #168