### PR TITLE
#177 [feature] Create Auto-Login

### DIFF
--- a/app/src/main/java/com/mate/baedalmate/presentation/activity/LoginActivity.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/activity/LoginActivity.kt
@@ -1,14 +1,121 @@
 package com.mate.baedalmate.presentation.activity
 
+import android.app.AlertDialog
+import android.content.ContentValues
+import android.content.Intent
+import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
+import android.view.ViewTreeObserver
+import androidx.activity.viewModels
+import androidx.lifecycle.Observer
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.install.model.UpdateAvailability
 import com.mate.baedalmate.R
+import com.mate.baedalmate.common.dialog.ConfirmAlertDialog
+import com.mate.baedalmate.databinding.ActivityLoginBinding
+import com.mate.baedalmate.presentation.viewmodel.MemberViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityLoginBinding
+    private val loginViewModel by viewModels<MemberViewModel>()
+    private lateinit var appUpdateManager: AppUpdateManager
+    private var isReady = false
+    private var isUpdateAvailable = false
+    private lateinit var updateDialog: AlertDialog
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_login)
+        binding = ActivityLoginBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        createDialogUpdate()
+        setSplash()
+        checkUpdate()
+    }
+
+    private fun checkUpdate() {
+        // TODO: 플레이스토어 출시 이전이므로 업데이트 체크 불가이기 때문에 체크 불가능한 경우 그냥 통과
+        appUpdateManager = AppUpdateManagerFactory.create(this)
+        val appUpdateInfoTask = appUpdateManager.appUpdateInfo
+
+        appUpdateInfoTask.addOnSuccessListener { appUpdateInfo ->
+            if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE) {
+                isUpdateAvailable = true
+                isReady = true
+                ConfirmAlertDialog.showConfirmDialog(updateDialog)
+                ConfirmAlertDialog.resizeDialogFragment(this, updateDialog, 0.8f)
+            }
+        }
+
+        if (!isUpdateAvailable) {
+            autoLogin()
+        }
+    }
+
+    private fun autoLogin() {
+        val intent = intent
+        val isValid = intent.getBooleanExtra("isValid", true)
+
+        if (isValid) {
+            loginViewModel.requestUserInfo()
+            loginViewModel.getUserInfoSuccess.observe(
+                this,
+                Observer { isSuccess ->
+                    if (isSuccess) {
+                        skipToNextActivity()
+                    } else if (isSuccess == false) {
+                        Log.e(ContentValues.TAG, "AccessToken 만료")
+                        isReady = true
+                    } else {
+                    }
+                }
+            )
+        } else {
+//            Lg.e("ACCOUNT IS NOT VALID")
+            isReady = true
+        }
+    }
+
+    private fun skipToNextActivity() {
+        isReady = false // 로그인이 성공한 경우에는 Splash 화면을 없애지 않고 바로 넘어가게 하기 위해 false 설정
+        val intent = Intent(this@LoginActivity, MainActivity::class.java)
+        intent.flags =
+            Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        startActivity(intent)
+        this@LoginActivity.finish()
+    }
+
+    private fun setSplash() {
+        binding.root.viewTreeObserver.addOnPreDrawListener(
+            object : ViewTreeObserver.OnPreDrawListener {
+                override fun onPreDraw(): Boolean {
+                    return if (isReady) {
+                        binding.root.viewTreeObserver.removeOnPreDrawListener(this)
+                        true
+                    } else
+                        false
+                }
+            }
+        )
+    }
+
+    private fun createDialogUpdate() {
+        updateDialog = ConfirmAlertDialog.createInfoDialog(
+            context = this,
+            title = getString(R.string.update_dialog_title),
+            description = getString(R.string.update_dialog_description),
+            confirmButtonFunction = {
+                val intent = Intent(Intent.ACTION_VIEW)
+                intent.addCategory(Intent.CATEGORY_DEFAULT)
+                intent.data =
+                    Uri.parse("http://play.google.com/store/apps/details?id=$packageName")
+                startActivity(intent)
+                finish()
+            }
+        )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="post_not_active">마감된 모집글입니다</string>
     <string name="post_cancel">모집 취소</string>
     <string name="post_delivery_fee_help_detail_title">배달비 상세정보</string>
+    <string name="post_delivery_fee_help_detail_description">배달팁 계산 시, 나누어 떨어지지 않는 경우 1원이 추가되어 계산됩니다.</string>
     <string name="post_delivery_fee_help_coupon_title">쿠폰 사용 금액</string>
     <string name="post_delivery_fee_help_coupon_description">기존 금액에서 주최자의 쿠폰 사용금액만큼 할인된 후 배달비가 나누기 됩니다.</string>
     <string name="coupon_amount">쿠폰사용금액</string>
@@ -122,6 +123,7 @@
     <string name="post_menu_add_description">추가할 메뉴와 금액을 작성하여, 모든 메뉴를 추가한 뒤 모집에 참여하세요</string>
     <string name="post_menu_added_title">현재 작성 메뉴</string>
     <string name="post_category_list_empty">현재 \'%s\' 에 대한\n모집글이 없어요</string>
+    <string name="post_category_list_load_fail">네트워크 통신이 원활하지 않습니다.</string>
     <string name="post_modify"><u>모집글 수정하기</u></string>
     <string name="post_cancel_dialog_title">모집을 취소하시겠습니까?</string>
     <string name="post_cancel_dialog_description">모집 취소 시, 지금까지 진행된 모집이 중단됩니다.</string>
@@ -330,6 +332,10 @@
     <string name="history_post_status_success">모집 성공</string>
     <string name="history_post_status_cancel">모집 취소</string>
     <string name="history_post_status_fail">모집 실패</string>
+
+    <!-- Update -->
+    <string name="update_dialog_title">업데이트</string>
+    <string name="update_dialog_description">업데이트가 필요합니다</string>
 
     <!-- Participant Profile -->
 </resources>


### PR DESCRIPTION
## 내용
- 기존 로그인 사용자에 대한 자동 로그인 구현
   - MainActivity에서 넘어온 경우 인증된 계정에 대해 유저 정보를 갱신한 뒤 MainActivity로 넘어가도록 설정
   - 인증된 계정 및 업데이트 확인 처리 시간동안 Splash 화면이 사라지지 않고 보여지도록 구현
- 새로운 버전 출시에 대비한 강제 업데이트 기능 구현

## 참고
- resolved: #177