### PR TITLE
#192 [refactoring] Fix WriteFirstFragment

### DIFF
--- a/app/src/main/java/com/mate/baedalmate/common/ListLiveData.kt
+++ b/app/src/main/java/com/mate/baedalmate/common/ListLiveData.kt
@@ -7,6 +7,11 @@ class ListLiveData<T> : MutableLiveData<ArrayList<T>>() {
         value = ArrayList()
     }
 
+    fun at(pos: Int): T {
+        val items: ArrayList<T>? = value
+        return items!![pos]
+    }
+
     fun add(item: T) {
         val items: ArrayList<T>? = value
         items!!.add(item)
@@ -31,6 +36,12 @@ class ListLiveData<T> : MutableLiveData<ArrayList<T>>() {
         return value?.size ?: 0
     }
 
+    fun replaceAt(pos: Int, item: T) {
+        val items: ArrayList<T>? = value
+        items!![pos] = item
+        value = items
+    }
+
     fun replaceAll(list: List<T>) {
         val items: ArrayList<T> = arrayListOf()
         items.addAll(list)
@@ -52,5 +63,10 @@ class ListLiveData<T> : MutableLiveData<ArrayList<T>>() {
     fun notifyChange() {
         val items: ArrayList<T>? = value
         value = items
+    }
+
+    fun contains(item: T): Boolean {
+        val items: ArrayList<T>? = value
+        return items!!.contains(item)
     }
 }

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/recruit/RecruitApiService.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/recruit/RecruitApiService.kt
@@ -1,6 +1,7 @@
 package com.mate.baedalmate.data.datasource.remote.recruit
 
 import com.mate.baedalmate.domain.model.RecruitDetail
+import com.mate.baedalmate.domain.model.RecruitDetailForModify
 import com.mate.baedalmate.domain.model.RecruitList
 import retrofit2.Response
 import retrofit2.http.Body
@@ -37,6 +38,11 @@ interface RecruitApiService {
     suspend fun requestRecruitPost(
         @Path("id") id: Int
     ): Response<RecruitDetail>
+
+    @GET("/api/v1/recruit/{id}/detail")
+    suspend fun requestRecruitPostDetailForModify(
+        @Path("id") id: Int
+    ): Response<RecruitDetailForModify>
 
     @GET("/api/v1/recruit/cancel/{id}")
     suspend fun requestCancelRecruitPost(@Path("id") id: Int): Response<Void>

--- a/app/src/main/java/com/mate/baedalmate/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/di/ServiceModule.kt
@@ -49,6 +49,7 @@ import com.mate.baedalmate.domain.usecase.recruit.RequestCloseRecruitPostUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestParticipateRecruitPostUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestRecruitListUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestRecruitMainListUseCase
+import com.mate.baedalmate.domain.usecase.recruit.RequestRecruitPostForModifyUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestRecruitPostUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestRecruitTagListUseCase
 import com.mate.baedalmate.domain.usecase.report.RequestPostReportRecruitUseCase
@@ -153,6 +154,10 @@ object ServiceModule {
     @Singleton
     @Provides
     fun provideRequestRecruitPostUseCase(recruitRepository: RecruitRepository): RequestRecruitPostUseCase = RequestRecruitPostUseCase(recruitRepository)
+
+    @Singleton
+    @Provides
+    fun provideRequestRecruitPostForModifyUseCase(recruitRepository: RecruitRepository): RequestRecruitPostForModifyUseCase = RequestRecruitPostForModifyUseCase(recruitRepository)
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/mate/baedalmate/data/repository/RecruitRepositoryImpl.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/repository/RecruitRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.mate.baedalmate.data.datasource.remote.recruit.RecruitApiService
 import com.mate.baedalmate.data.datasource.remote.recruit.TagRecruitList
 import com.mate.baedalmate.domain.model.ApiResult
 import com.mate.baedalmate.domain.model.RecruitDetail
+import com.mate.baedalmate.domain.model.RecruitDetailForModify
 import com.mate.baedalmate.domain.model.RecruitDto
 import com.mate.baedalmate.domain.model.setExceptionHandling
 import com.mate.baedalmate.domain.repository.RecruitRepository
@@ -54,6 +55,11 @@ class RecruitRepositoryImpl @Inject constructor(private val recruitApiService: R
     override suspend fun requestRecruitPost(id: Int): ApiResult<RecruitDetail> =
         setExceptionHandling {
             recruitApiService.requestRecruitPost(id = id)
+        }
+
+    override suspend fun requestRecruitPostDetailForModify(id: Int): ApiResult<RecruitDetailForModify> =
+        setExceptionHandling {
+            recruitApiService.requestRecruitPostDetailForModify(id = id)
         }
 
     override suspend fun requestCancelRecruitPost(id: Int): ApiResult<Void> =

--- a/app/src/main/java/com/mate/baedalmate/domain/model/MenuDto.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/model/MenuDto.kt
@@ -1,7 +1,10 @@
 package com.mate.baedalmate.domain.model
 
+import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class MenuDto (
     @SerializedName("name")
     val name: String,
@@ -9,4 +12,4 @@ data class MenuDto (
     val price: Int,
     @SerializedName("quantity")
     val quantity: Int,
-)
+): Parcelable

--- a/app/src/main/java/com/mate/baedalmate/domain/model/PlaceDto.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/model/PlaceDto.kt
@@ -1,7 +1,10 @@
 package com.mate.baedalmate.domain.model
 
+import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
+import kotlinx.android.parcel.Parcelize
 
+@Parcelize
 data class PlaceDto(
     @SerializedName("addressName")
     val addressName: String,
@@ -13,4 +16,4 @@ data class PlaceDto(
     val x: Float,
     @SerializedName("y")
     val y: Float,
-)
+): Parcelable

--- a/app/src/main/java/com/mate/baedalmate/domain/model/RecruitDetail.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/model/RecruitDetail.kt
@@ -1,7 +1,9 @@
 package com.mate.baedalmate.domain.model
 
+import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import com.mate.baedalmate.data.datasource.remote.member.UserInfoResponse
+import kotlinx.parcelize.Parcelize
 
 data class RecruitDetail(
     @SerializedName("active")
@@ -47,3 +49,39 @@ data class RecruitDetail(
     @SerializedName("cancel")
     val cancel: Boolean
 )
+
+@Parcelize
+data class RecruitDetailForModify(
+    @SerializedName("recruitId")
+    val recruitId: Int,
+    @SerializedName("categoryId")
+    val categoryId: Int,
+    @SerializedName("place")
+    val place: PlaceDto,
+    @SerializedName("dormitory")
+    val dormitory: String,
+    @SerializedName("criteria")
+    val criteria: RecruitFinishCriteria,
+    @SerializedName("minPrice")
+    val minPrice: Int,
+    @SerializedName("minPeople")
+    val minPeople: Int,
+    @SerializedName("shippingFee")
+    val shippingFee: List<ShippingFeeDto>,
+    @SerializedName("coupon")
+    val coupon: Int,
+    @SerializedName("platform")
+    val platform: String,
+    @SerializedName("deadlineDate")
+    val deadlineDate: String,
+    @SerializedName("title")
+    val title: String,
+    @SerializedName("description")
+    val description: String,
+    @SerializedName("freeShipping")
+    val freeShipping: Boolean,
+    @SerializedName("menu")
+    val menu: List<MenuDto>,
+    @SerializedName("tags")
+    val tags: List<TagDto>
+): Parcelable

--- a/app/src/main/java/com/mate/baedalmate/domain/model/TagDto.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/model/TagDto.kt
@@ -1,8 +1,11 @@
 package com.mate.baedalmate.domain.model
 
+import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class TagDto (
     @SerializedName("tagname")
     val tagname: String
-)
+): Parcelable

--- a/app/src/main/java/com/mate/baedalmate/domain/repository/RecruitRepository.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/repository/RecruitRepository.kt
@@ -8,6 +8,7 @@ import com.mate.baedalmate.data.datasource.remote.recruit.MainRecruitList
 import com.mate.baedalmate.data.datasource.remote.recruit.TagRecruitList
 import com.mate.baedalmate.domain.model.ApiResult
 import com.mate.baedalmate.domain.model.RecruitDetail
+import com.mate.baedalmate.domain.model.RecruitDetailForModify
 import com.mate.baedalmate.domain.model.RecruitDto
 import kotlinx.coroutines.flow.Flow
 
@@ -21,6 +22,7 @@ interface RecruitRepository {
 
     suspend fun requestRecruitTagList(page: Int, size: Int, sort: String): ApiResult<TagRecruitList>
     suspend fun requestRecruitPost(id: Int): ApiResult<RecruitDetail>
+    suspend fun requestRecruitPostDetailForModify(id: Int): ApiResult<RecruitDetailForModify>
     suspend fun requestCancelRecruitPost(id: Int): ApiResult<Void>
     suspend fun requestCloseRecruitPost(id: Int): ApiResult<Void>
     suspend fun requestParticipateRecruitPost(data: CreateOrderRequest): ApiResult<CreateOrderResponse>

--- a/app/src/main/java/com/mate/baedalmate/domain/usecase/recruit/RequestRecruitPostForModifyUseCase.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/usecase/recruit/RequestRecruitPostForModifyUseCase.kt
@@ -1,0 +1,11 @@
+package com.mate.baedalmate.domain.usecase.recruit
+
+import com.mate.baedalmate.domain.repository.RecruitRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RequestRecruitPostForModifyUseCase @Inject constructor(private val recruitRepository: RecruitRepository) {
+    suspend operator fun invoke(id: Int) =
+        recruitRepository.requestRecruitPostDetailForModify(id = id)
+}

--- a/app/src/main/java/com/mate/baedalmate/presentation/adapter/write/WriteFirstDeliveryFeeRangeAdapter.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/adapter/write/WriteFirstDeliveryFeeRangeAdapter.kt
@@ -1,0 +1,150 @@
+package com.mate.baedalmate.presentation.adapter.write
+
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import com.mate.baedalmate.R
+import com.mate.baedalmate.common.ListLiveData
+import com.mate.baedalmate.common.extension.setOnDebounceClickListener
+import com.mate.baedalmate.databinding.ItemWriteFirstDeliveryFeeRangeBinding
+import com.mate.baedalmate.domain.model.ShippingFeeDto
+
+class WriteFirstDeliveryFeeRangeAdapter(
+    var items: MutableList<ShippingFeeDto>,
+    var deliveryFeeRangeCorrectList: ListLiveData<Boolean>,
+    var deliveryFeeRangeEmptyChkList: ListLiveData<Boolean>
+) :
+    RecyclerView.Adapter<WriteFirstDeliveryFeeRangeAdapter.WriteFirstDeliveryFeeRangeViewHolder>() {
+    interface OnItemClickListener {
+        fun removeItem(contents: ShippingFeeDto, pos: Int)
+    }
+
+    private var listener: OnItemClickListener? = null
+    fun setOnItemClickListener(listener: OnItemClickListener) {
+        this.listener = listener
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): WriteFirstDeliveryFeeRangeViewHolder =
+        WriteFirstDeliveryFeeRangeViewHolder(
+            ItemWriteFirstDeliveryFeeRangeBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+
+    override fun onBindViewHolder(
+        holder: WriteFirstDeliveryFeeRangeAdapter.WriteFirstDeliveryFeeRangeViewHolder,
+        position: Int,
+    ) {
+        val item = items[position]
+        holder.bind(item, position)
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return position
+    }
+
+    inner class WriteFirstDeliveryFeeRangeViewHolder(private val binding: ItemWriteFirstDeliveryFeeRangeBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(contents: ShippingFeeDto, position: Int) {
+            with(binding) {
+                tvDeliveryFeeRangeTitle.text = "구간 ${bindingAdapterPosition + 1}"
+                etDeliveryFeeRange.setText("${contents.lowerPrice}")
+                etDeliveryFee.setText("${contents.shippingFee}")
+
+                if (bindingAdapterPosition == 0) btnDeliveryFeeRangeDelete.visibility = View.GONE
+                btnDeliveryFeeRangeDelete.setOnDebounceClickListener {
+                    with(etDeliveryFee) {
+                        clearTextChangedListeners()
+                        text = null
+                    }
+                    with(etDeliveryFeeRange) {
+                        clearTextChangedListeners()
+                        text = null
+                    }
+                    listener?.removeItem(contents, bindingAdapterPosition)
+                }
+                etDeliveryFee.isEnabled = (bindingAdapterPosition == items.size - 1)
+                etDeliveryFeeRange.isEnabled = (bindingAdapterPosition == items.size - 1)
+                etDeliveryFeeRange.addTextChangedListener(object : TextWatcher {
+                    override fun beforeTextChanged(
+                        s: CharSequence?, start: Int, count: Int, after: Int
+                    ) {
+                    }
+
+                    override fun onTextChanged(
+                        s: CharSequence?, start: Int, before: Int, count: Int
+                    ) {
+                    }
+
+                    override fun afterTextChanged(s: Editable?) {
+                        val changedRange = ShippingFeeDto(
+                            if (s?.toString().isNullOrEmpty()) 0 else s?.toString()?.toInt() ?: 0,
+                            items[bindingAdapterPosition].shippingFee,
+                            items[bindingAdapterPosition].upperPrice
+                        )
+                        items[bindingAdapterPosition] = changedRange
+
+                        deliveryFeeRangeEmptyChkList.replaceAt(
+                            bindingAdapterPosition,
+                            !(binding.etDeliveryFeeRange.text.isNullOrEmpty() || binding.etDeliveryFee.text.isNullOrEmpty())
+                        )
+
+                        if (s.toString().isNotEmpty() && bindingAdapterPosition != 0) {
+                            if (items[bindingAdapterPosition - 1].lowerPrice >= // 직전의 range
+                                items[bindingAdapterPosition].lowerPrice
+                            ) {
+                                binding.etDeliveryFeeRange.background = ContextCompat.getDrawable(
+                                    binding.etDeliveryFeeRange.context,
+                                    R.drawable.background_white_radius_10_stroke_red
+                                )
+                                deliveryFeeRangeCorrectList.replaceAt(bindingAdapterPosition, false)
+                            } else {
+                                binding.etDeliveryFeeRange.background = ContextCompat.getDrawable(
+                                    binding.etDeliveryFeeRange.context,
+                                    R.drawable.selector_edittext_white_gray_line_radius_10
+                                )
+                                deliveryFeeRangeCorrectList.replaceAt(bindingAdapterPosition, true)
+                            }
+                        }
+                    }
+                })
+                etDeliveryFee.addTextChangedListener(object : TextWatcher {
+                    override fun beforeTextChanged(
+                        s: CharSequence?, start: Int, count: Int, after: Int
+                    ) {
+                    }
+
+                    override fun onTextChanged(
+                        s: CharSequence?, start: Int, before: Int, count: Int
+                    ) {
+                    }
+
+                    override fun afterTextChanged(s: Editable?) {
+                        val changedRange = ShippingFeeDto(
+                            items[bindingAdapterPosition].lowerPrice,
+                            if (s?.toString().isNullOrEmpty()) 0 else s?.toString()?.toInt() ?: 0,
+                            items[bindingAdapterPosition].upperPrice
+                        )
+                        items[bindingAdapterPosition] = changedRange
+
+                        deliveryFeeRangeEmptyChkList.replaceAt(
+                            bindingAdapterPosition,
+                            !(binding.etDeliveryFeeRange.text.isNullOrEmpty() || binding.etDeliveryFee.text.isNullOrEmpty())
+                        )
+                    }
+                })
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/post/PostFragment.kt
@@ -18,7 +18,9 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
@@ -176,7 +178,8 @@ class PostFragment : Fragment() {
                     )
                 )
             }
-            starIndicator[i]!!.imageTintList = ContextCompat.getColorStateList(requireContext(), R.color.main_FB5F1C)
+            starIndicator[i]!!.imageTintList =
+                ContextCompat.getColorStateList(requireContext(), R.color.main_FB5F1C)
             starIndicator[i]!!.layoutParams = params
             binding.layoutPostFrontUserScore.addView(starIndicator[i])
         }
@@ -401,6 +404,7 @@ class PostFragment : Fragment() {
                     initContentsPostInfo(recruitDetail)
                     setRecruitActionButton(recruitDetail)
                     setReportPostClickListener(recruitDetail)
+                    requestRecruitPostDetailForModify(recruitDetail)
                     setModifyPostClickListener(recruitDetail)
                 }
             }
@@ -426,11 +430,27 @@ class PostFragment : Fragment() {
         }
     }
 
+    private fun requestRecruitPostDetailForModify(recruitDetail: RecruitDetail) {
+        if (recruitDetail.host) {
+            viewLifecycleOwner.lifecycleScope.launch {
+                viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    recruitViewModel.requestRecruitPostForModify(postId = recruitDetail.recruitId)
+                }
+            }
+        }
+    }
+
     private fun setModifyPostClickListener(recruitDetail: RecruitDetail) {
         with(binding.tvPostFrontContentsDetailModify) {
             visibility = if (recruitDetail.host && recruitDetail.active) View.VISIBLE else View.GONE
-            setOnDebounceClickListener {
-                // TODO 수정하기 구현 추가시 Navigate 추가
+            recruitViewModel.recruitPostDetailForModify.observe(viewLifecycleOwner) { recruitDetailForModify ->
+                setOnDebounceClickListener {
+                    findNavController().navigate(
+                        PostFragmentDirections.actionPostFragmentToModifyPostFragment(
+                            recruitDetailForModify
+                        )
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/write/WriteCategoryFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/write/WriteCategoryFragment.kt
@@ -68,7 +68,11 @@ class WriteCategoryFragment : Fragment() {
             if (childView is ShapeableImageView) {
                 childView.setOnClickListener {
                     writeViewModel.categoryId = (i / 3) + 1
-                    findNavController().navigate(R.id.action_writeCategoryFragment_to_writeFirstFragment)
+                    findNavController().navigate(
+                        WriteCategoryFragmentDirections.actionWriteCategoryFragmentToWriteFirstFragment(
+                            null
+                        )
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/mate/baedalmate/presentation/viewmodel/RecruitViewModel.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/viewmodel/RecruitViewModel.kt
@@ -18,6 +18,7 @@ import com.mate.baedalmate.domain.model.ApiResult
 import com.mate.baedalmate.domain.model.MenuDto
 import com.mate.baedalmate.domain.model.PlaceDto
 import com.mate.baedalmate.domain.model.RecruitDetail
+import com.mate.baedalmate.domain.model.RecruitDetailForModify
 import com.mate.baedalmate.domain.model.RecruitDto
 import com.mate.baedalmate.domain.usecase.recruit.RequestCancelParticipateRecruitPostUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestCancelRecruitPostUseCase
@@ -25,6 +26,7 @@ import com.mate.baedalmate.domain.usecase.recruit.RequestCloseRecruitPostUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestParticipateRecruitPostUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestRecruitListUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestRecruitMainListUseCase
+import com.mate.baedalmate.domain.usecase.recruit.RequestRecruitPostForModifyUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestRecruitPostUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestRecruitTagListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -40,6 +42,7 @@ class RecruitViewModel @Inject constructor(
     private val recruitMainListUseCase: RequestRecruitMainListUseCase,
     private val recruitTagListUseCase: RequestRecruitTagListUseCase,
     private val recruitPostUseCase: RequestRecruitPostUseCase,
+    private val recruitPostForModifyUseCase: RequestRecruitPostForModifyUseCase,
     private val closeRecruitPostUseCase: RequestCloseRecruitPostUseCase,
     private val cancelRecruitPostUseCase: RequestCancelRecruitPostUseCase,
     private val participateRecruitPostUseCase: RequestParticipateRecruitPostUseCase,
@@ -114,6 +117,9 @@ class RecruitViewModel @Inject constructor(
         )
     )
     val recruitPostDetail: LiveData<RecruitDetail> get() = _recruitPostDetail
+
+    private val _recruitPostDetailForModify = MutableLiveData<RecruitDetailForModify>()
+    val recruitPostDetailForModify get() = _recruitPostDetailForModify
 
     private val _recruitHomeRecentList = MutableLiveData(
         MainRecruitList(
@@ -217,6 +223,16 @@ class RecruitViewModel @Inject constructor(
             when (ApiResponse.status) {
                 ApiResult.Status.SUCCESS -> {
                     ApiResponse.data.let { _recruitPostDetail.postValue(it) }
+                }
+            }
+        }
+    }
+
+    fun requestRecruitPostForModify(postId: Int) = viewModelScope.launch {
+        recruitPostForModifyUseCase.invoke(id = postId).let { ApiResponse ->
+            when (ApiResponse.status) {
+                ApiResult.Status.SUCCESS -> {
+                    ApiResponse.data.let { _recruitPostDetailForModify.postValue(it) }
                 }
             }
         }

--- a/app/src/main/res/layout/fragment_write_first.xml
+++ b/app/src/main/res/layout/fragment_write_first.xml
@@ -13,7 +13,8 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="@color/white_FFFFFF">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_write_first_actionbar"
@@ -270,6 +271,7 @@
                             android:maxLines="1"
                             android:paddingVertical="13dp"
                             android:paddingStart="15dp"
+                            android:text="0"
                             android:textColor="@color/black_000000"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintEnd_toStartOf="@id/tv_write_first_goal_delivery_user_input_unit"
@@ -603,125 +605,19 @@
                             android:text="@string/write_first_delivery_fee_free_not" />
                     </RadioGroup>
 
-                    <LinearLayout
-                        android:id="@+id/layout_write_first_delivery_fee_range"
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/rv_write_first_delivery_fee_range"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="15dp"
-                        android:animateLayoutChanges="true"
                         android:orientation="vertical"
                         android:visibility="gone"
-                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/radiogroup_write_first_delivery_fee"
-                        app:layout_constraintVertical_bias="0.0">
-
-                        <androidx.constraintlayout.widget.ConstraintLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginBottom="15dp">
-
-                            <androidx.constraintlayout.widget.ConstraintLayout
-                                android:id="@+id/layout_delivery_fee_range"
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                app:layout_constraintBottom_toBottomOf="parent"
-                                app:layout_constraintEnd_toStartOf="@id/btn_delivery_fee_range_delete"
-                                app:layout_constraintHorizontal_bias="0.0"
-                                app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintTop_toTopOf="parent"
-                                app:layout_constraintVertical_bias="0.0">
-
-                                <TextView
-                                    android:id="@+id/tv_delivery_fee_range_title"
-                                    style="@style/style_body2_kor"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="구간1"
-                                    android:textColor="@color/black_000000"
-                                    app:layout_constraintBottom_toBottomOf="@id/et_delivery_fee_range"
-                                    app:layout_constraintEnd_toEndOf="parent"
-                                    app:layout_constraintHorizontal_bias="0.0"
-                                    app:layout_constraintStart_toStartOf="parent"
-                                    app:layout_constraintTop_toTopOf="@id/et_delivery_fee_range"
-                                    app:layout_constraintVertical_bias="0.5" />
-
-                                <com.mate.baedalmate.common.ExtendedEditText
-                                    android:id="@+id/et_delivery_fee_range"
-                                    style="@style/style_body1_kor"
-                                    android:layout_width="0dp"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginStart="25dp"
-                                    android:layout_marginEnd="5dp"
-                                    android:background="@drawable/selector_edittext_white_gray_line_radius_10"
-                                    android:gravity="end"
-                                    android:inputType="number"
-                                    android:maxLength="9"
-                                    android:nextFocusDown="@id/et_delivery_fee"
-                                    android:paddingHorizontal="15dp"
-                                    android:paddingVertical="10dp"
-                                    android:textColor="@drawable/selector_textview_black_gray_main"
-                                    app:layout_constraintBottom_toBottomOf="parent"
-                                    app:layout_constraintEnd_toEndOf="parent"
-                                    app:layout_constraintHorizontal_bias="0.0"
-                                    app:layout_constraintStart_toEndOf="@id/tv_delivery_fee_range_title"
-                                    app:layout_constraintTop_toTopOf="parent"
-                                    app:layout_constraintVertical_bias="0.0"
-                                    tools:text="0원" />
-
-                                <TextView
-                                    android:id="@+id/tv_delivery_fee_title"
-                                    style="@style/style_body2_kor"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/amount"
-                                    android:textColor="@color/black_000000"
-                                    app:layout_constraintBottom_toBottomOf="@id/et_delivery_fee"
-                                    app:layout_constraintEnd_toEndOf="parent"
-                                    app:layout_constraintHorizontal_bias="0.0"
-                                    app:layout_constraintStart_toStartOf="parent"
-                                    app:layout_constraintTop_toTopOf="@id/et_delivery_fee"
-                                    app:layout_constraintVertical_bias="0.5" />
-
-                                <com.mate.baedalmate.common.ExtendedEditText
-                                    android:id="@+id/et_delivery_fee"
-                                    style="@style/style_title2_kor"
-                                    android:layout_width="0dp"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginTop="10dp"
-                                    android:background="@drawable/selector_edittext_white_gray_line_radius_10"
-                                    android:gravity="end"
-                                    android:inputType="number"
-                                    android:maxLength="9"
-                                    android:paddingHorizontal="15dp"
-                                    android:paddingVertical="10dp"
-                                    android:textColor="@drawable/selector_textview_black_gray_main"
-                                    app:layout_constraintBottom_toBottomOf="parent"
-                                    app:layout_constraintEnd_toEndOf="@id/et_delivery_fee_range"
-                                    app:layout_constraintHorizontal_bias="0.0"
-                                    app:layout_constraintStart_toStartOf="@id/et_delivery_fee_range"
-                                    app:layout_constraintTop_toBottomOf="@id/et_delivery_fee_range"
-                                    app:layout_constraintVertical_bias="0.0"
-                                    tools:text="0원" />
-                            </androidx.constraintlayout.widget.ConstraintLayout>
-
-                            <ImageButton
-                                android:id="@+id/btn_delivery_fee_range_delete"
-                                android:layout_width="45dp"
-                                android:layout_height="0dp"
-                                android:background="@drawable/background_white_radius_10"
-                                android:backgroundTint="@color/gray_line_EBEBEB"
-                                android:src="@drawable/ic_sign_x_gray_dark"
-                                android:visibility="invisible"
-                                app:layout_constraintBottom_toBottomOf="parent"
-                                app:layout_constraintEnd_toEndOf="parent"
-                                app:layout_constraintHorizontal_bias="1.0"
-                                app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintTop_toTopOf="parent"
-                                app:layout_constraintVertical_bias="0.0" />
-                        </androidx.constraintlayout.widget.ConstraintLayout>
-                    </LinearLayout>
+                        app:layout_constraintVertical_bias="0.0"
+                        tools:itemCount="5"
+                        tools:listitem="@layout/item_write_first_delivery_fee_range" />
 
                     <androidx.appcompat.widget.AppCompatButton
                         android:id="@+id/btn_write_first_delivery_fee_range_add"
@@ -737,7 +633,7 @@
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/layout_write_first_delivery_fee_range" />
+                        app:layout_constraintTop_toBottomOf="@id/rv_write_first_delivery_fee_range" />
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -124,6 +124,13 @@
             app:exitAnim="@anim/fade_out"
             app:popEnterAnim="@anim/fade_in"
             app:popExitAnim="@anim/slide_out" />
+        <action
+            android:id="@+id/action_postFragment_to_modifyPostFragment"
+            app:destination="@id/WriteFirstFragment"
+            app:enterAnim="@anim/slide_in"
+            app:exitAnim="@anim/fade_out"
+            app:popEnterAnim="@anim/fade_in"
+            app:popExitAnim="@anim/slide_out" />
     </fragment>
     <dialog
         android:id="@+id/PostMapFragment"
@@ -199,6 +206,10 @@
         android:name="com.mate.baedalmate.presentation.fragment.write.WriteFirstFragment"
         android:label="fragment_write_first"
         tools:layout="@layout/fragment_write_first">
+        <argument
+            android:name="recruitDetailForModify"
+            app:argType="com.mate.baedalmate.domain.model.RecruitDetailForModify"
+            app:nullable="true" />
         <action
             android:id="@+id/action_writeFirstFragment_to_writeSecondFragment"
             app:destination="@id/WriteSecondFragment"
@@ -220,6 +231,10 @@
         android:name="com.mate.baedalmate.presentation.fragment.write.WriteSecondFragment"
         android:label="fragment_write_first"
         tools:layout="@layout/fragment_write_second">
+        <argument
+            android:name="recruitDetailForModify"
+            app:argType="com.mate.baedalmate.domain.model.RecruitDetailForModify"
+            app:nullable="true" />
         <action
             android:id="@+id/action_writeSecondFragment_to_writeSecondPlaceDialogFragment"
             app:destination="@id/WriteSecondPlaceDialogFragment" />
@@ -241,6 +256,10 @@
         android:name="com.mate.baedalmate.presentation.fragment.write.WriteThirdFragment"
         android:label="fragment_write_third"
         tools:layout="@layout/fragment_write_third">
+        <argument
+            android:name="recruitDetailForModify"
+            app:argType="com.mate.baedalmate.domain.model.RecruitDetailForModify"
+            app:nullable="true" />
         <action
             android:id="@+id/action_writeThirdFragment_to_writeFourthFragment"
             app:destination="@id/WriteFourthFragment"
@@ -254,6 +273,10 @@
         android:name="com.mate.baedalmate.presentation.fragment.write.WriteFourthFragment"
         android:label="fragment_write_fourth"
         tools:layout="@layout/fragment_write_fourth">
+        <argument
+            android:name="recruitDetailForModify"
+            app:argType="com.mate.baedalmate.domain.model.RecruitDetailForModify"
+            app:nullable="true" />
         <action
             android:id="@+id/action_writeFourthFragment_to_writeFourthAddMenuFragment"
             app:destination="@id/WriteFourthAddMenuFragment" />


### PR DESCRIPTION
## 내용 및 작업사항
### 공통
- `ListLiveData` 함수 추가
   - `at`, `replaceAt`, `contains`
### 글 수정하기
- PostFragment에서 해당 모집글 작성자 ID와 현재 로그인한 사용자의 ID가 동일한 경우 글 수정하기에 필요한 정보를 받아오는 API 추가 및 관련 네트워크 코드 구현
   - 해당 API 응답에 사용되는 `RecruitDetailForModify` Data Class 추가
- 기존 모집글 상세보기 관련 DTO들에 대해 `Safe args`를 통해 Fragment 전달을 위해 `Parcelize` Annotation 추가 및 `Parcelable` 적용
   - `MenuDto`, `PlaceDto`, `TagDto`
- 글 수정하기 버튼 클릭시 기존 글 작성하기 Fragment로 이동
   - 카테고리 수정 Fragment는 건너뛰도록 설정

### WriteFirstFragment 로직 수정
- WriteFirstFragment 배달비 구간을 중점적으로 구조 개편 및 전반적인 리팩토링 실행
   - 기존 배달비 구간 추가시 XML Layout 파일을 inflate시켜 `직접 addView 및 remove`했던 것을 `RecyclerView` 등을 활용해 구현하도록 구현 방식 변경
      - `WriteFirstDeliveryFeeRangeAdapter` 생성 및 삭제및 에러처리 표시 등 관련 동작 구현
      - `Item` 삭제시 등장하는 애니메이션 수정
- `Fragment`에서 입력받는 영역에 대한 초기화 진행 후, 수정하는 경우에 대한 처리를 실행하도록 구현
- 기존에 같은 함수에 들어있던 여러 동작들에 대해 세분화 및 각 함수가 하나의 역할을 맡을 수 있도록 세분화 처리
- 이외 `with` 사용등 리팩토링 진행

## 참고
- resolved: #192