### PR TITLE
#196 [feature] Create Infinity Scroll with Recruit Post Result

### DIFF
--- a/app/src/main/java/com/mate/baedalmate/data/datasource/PostHistoryPagingSource.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/PostHistoryPagingSource.kt
@@ -1,0 +1,63 @@
+package com.mate.baedalmate.data.datasource
+
+import android.accounts.NetworkErrorException
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.mate.baedalmate.data.datasource.remote.member.HistoryRecruitResponseDto
+import com.mate.baedalmate.data.datasource.remote.member.MemberApiService
+import com.mate.baedalmate.domain.model.ApiResult
+import com.mate.baedalmate.domain.model.setExceptionHandling
+import kotlinx.coroutines.delay
+
+private const val POST_LIST_STARTING_PAGE_INDEX = 0
+private const val DELAY_MILLIS = 1_000L
+
+class PostHistoryPagingSource(
+    private val memberApiService: MemberApiService,
+    private val isHostingPosts: Boolean,
+    private val sort: String
+) : PagingSource<Int, HistoryRecruitResponseDto>() {
+    override fun getRefreshKey(state: PagingState<Int, HistoryRecruitResponseDto>): Int? {
+        return state.anchorPosition?.let { position ->
+            state.closestPageToPosition(position)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(position)?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, HistoryRecruitResponseDto> {
+        val position = params.key ?: POST_LIST_STARTING_PAGE_INDEX
+        if (position != POST_LIST_STARTING_PAGE_INDEX) delay(DELAY_MILLIS)
+
+        return try {
+            val response = setExceptionHandling {
+                if (isHostingPosts) {
+                    memberApiService.requestGetHistoryPostCreated(
+                        page = position,
+                        size = 6,
+                        sort = sort
+                    )
+                } else {
+                    memberApiService.requestGetHistoryPostParticipated(
+                        page = position,
+                        size = 6,
+                        sort = sort
+                    )
+                }
+            }
+            when (response.status) {
+                ApiResult.Status.SUCCESS -> {
+                    LoadResult.Page(
+                        data = response.data!!.recruitList,
+                        prevKey = null, // Only Paging Forward
+                        nextKey = if (response.data.last) null else position + 1
+                    )
+                }
+                else -> {
+                    throw NetworkErrorException("API RESULT FAIL")
+                }
+            }
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+}

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/PostSearchResultPagingSource.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/PostSearchResultPagingSource.kt
@@ -1,0 +1,57 @@
+package com.mate.baedalmate.data.datasource
+
+import android.accounts.NetworkErrorException
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.mate.baedalmate.data.datasource.remote.search.SearchApiService
+import com.mate.baedalmate.domain.model.ApiResult
+import com.mate.baedalmate.domain.model.RecruitDto
+import com.mate.baedalmate.domain.model.setExceptionHandling
+import kotlinx.coroutines.delay
+
+private const val POST_LIST_STARTING_PAGE_INDEX = 0
+private const val DELAY_MILLIS = 1_000L
+
+class PostSearchResultPagingSource(
+    private val searchApiService: SearchApiService,
+    private val keyword: String,
+    private val sort: String
+) :
+    PagingSource<Int, RecruitDto>() {
+    override fun getRefreshKey(state: PagingState<Int, RecruitDto>): Int? {
+        return state.anchorPosition?.let { position ->
+            state.closestPageToPosition(position)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(position)?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, RecruitDto> {
+        val position = params.key ?: POST_LIST_STARTING_PAGE_INDEX
+        if (position != POST_LIST_STARTING_PAGE_INDEX) delay(DELAY_MILLIS)
+
+        return try {
+            val response = setExceptionHandling {
+                searchApiService.requestGetSearchTagKeyword(
+                    keyword = keyword,
+                    page = position,
+                    size = 6,
+                    sort = sort
+                )
+            }
+            when (response.status) {
+                ApiResult.Status.SUCCESS -> {
+                    LoadResult.Page(
+                        data = response.data!!.recruitList,
+                        prevKey = null, // Only Paging Forward
+                        nextKey = if (response.data.last) null else position + 1
+                    )
+                }
+                else -> {
+                    throw NetworkErrorException("API RESULT FAIL")
+                }
+            }
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+}

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/member/MemberResponse.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/member/MemberResponse.kt
@@ -25,7 +25,9 @@ data class UserInfoResponse(
 
 data class HistoryRecruitList (
     @SerializedName("recruitList")
-    val recruitList: List<HistoryRecruitResponseDto>
+    val recruitList: List<HistoryRecruitResponseDto>,
+    @SerializedName("last")
+    val last: Boolean
 )
 
 data class HistoryRecruitResponseDto (

--- a/app/src/main/java/com/mate/baedalmate/data/repository/MemberRepositoryImpl.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/repository/MemberRepositoryImpl.kt
@@ -1,6 +1,10 @@
 package com.mate.baedalmate.data.repository
 
-import com.mate.baedalmate.data.datasource.remote.member.HistoryRecruitList
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import com.mate.baedalmate.data.datasource.PostHistoryPagingSource
+import com.mate.baedalmate.data.datasource.remote.member.HistoryRecruitResponseDto
 import com.mate.baedalmate.data.datasource.remote.member.MemberApiService
 import com.mate.baedalmate.data.datasource.remote.member.MemberOAuthRequest
 import com.mate.baedalmate.data.datasource.remote.member.MemberOAuthResponse
@@ -9,9 +13,9 @@ import com.mate.baedalmate.data.datasource.remote.member.UpdateDormitoryDto
 import com.mate.baedalmate.data.datasource.remote.member.UserInfoResponse
 import com.mate.baedalmate.domain.model.ApiResult
 import com.mate.baedalmate.domain.model.Dormitory
-import com.mate.baedalmate.domain.model.UpdateUserDto
 import com.mate.baedalmate.domain.model.setExceptionHandling
 import com.mate.baedalmate.domain.repository.MemberRepository
+import kotlinx.coroutines.flow.Flow
 import okhttp3.MultipartBody
 import javax.inject.Inject
 
@@ -39,31 +43,29 @@ class MemberRepositoryImpl @Inject constructor(private val memberApiService: Mem
     ): ApiResult<UserInfoResponse> =
         setExceptionHandling { memberApiService.requestPostChangeMyProfile(default_image = isChangingDefaultImage,nickname = newNickname, uploadfile = uploadfile) }
 
-    override suspend fun requestGetHistoryPostCreated(
-        page: Int,
-        size: Int,
-        sort: String
-    ): ApiResult<HistoryRecruitList> =
-        setExceptionHandling {
-            memberApiService.requestGetHistoryPostCreated(
-                page = page,
-                size = size,
-                sort = sort
-            )
-        }
+    override suspend fun requestGetHistoryPostCreated(sort: String): Flow<PagingData<HistoryRecruitResponseDto>> =
+        Pager(
+            config = PagingConfig(pageSize = 6, maxSize = 30, enablePlaceholders = false),
+            pagingSourceFactory = {
+                PostHistoryPagingSource(
+                    memberApiService,
+                    isHostingPosts = true,
+                    sort
+                )
+            }
+        ).flow
 
-    override suspend fun requestGetHistoryPostParticipated(
-        page: Int,
-        size: Int,
-        sort: String
-    ): ApiResult<HistoryRecruitList>  =
-        setExceptionHandling {
-            memberApiService.requestGetHistoryPostParticipated(
-                page = page,
-                size = size,
-                sort = sort
-            )
-        }
+    override suspend fun requestGetHistoryPostParticipated(sort: String): Flow<PagingData<HistoryRecruitResponseDto>> =
+        Pager(
+            config = PagingConfig(pageSize = 6, maxSize = 30, enablePlaceholders = false),
+            pagingSourceFactory = {
+                PostHistoryPagingSource(
+                    memberApiService,
+                    isHostingPosts = false,
+                    sort
+                )
+            }
+        ).flow
 
     override suspend fun requestPostLogout(): ApiResult<ResultSuccessResponseDto> =
         setExceptionHandling { memberApiService.requestPostLogout() }

--- a/app/src/main/java/com/mate/baedalmate/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/repository/SearchRepositoryImpl.kt
@@ -1,23 +1,22 @@
 package com.mate.baedalmate.data.repository
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import com.mate.baedalmate.data.datasource.PostSearchResultPagingSource
 import com.mate.baedalmate.data.datasource.remote.search.SearchApiService
-import com.mate.baedalmate.domain.model.ApiResult
-import com.mate.baedalmate.domain.model.RecruitList
-import com.mate.baedalmate.domain.model.setExceptionHandling
+import com.mate.baedalmate.domain.model.RecruitDto
 import com.mate.baedalmate.domain.repository.SearchRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class SearchRepositoryImpl @Inject constructor(private val searchApiService: SearchApiService) :
     SearchRepository {
     override suspend fun requestGetSearchTagKeyword(
         keyword: String,
-        page: Int,
-        size: Int,
         sort: String
-    ): ApiResult<RecruitList> =
-        setExceptionHandling {
-            searchApiService.requestGetSearchTagKeyword(
-                keyword = keyword, page = page, size = size, sort = sort
-            )
-        }
+    ): Flow<PagingData<RecruitDto>> = Pager(
+        config = PagingConfig(pageSize = 6, maxSize = 30, enablePlaceholders = false),
+        pagingSourceFactory = { PostSearchResultPagingSource(searchApiService, keyword, sort) }
+    ).flow
 }

--- a/app/src/main/java/com/mate/baedalmate/domain/repository/MemberRepository.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/repository/MemberRepository.kt
@@ -1,29 +1,23 @@
 package com.mate.baedalmate.domain.repository
 
-import com.mate.baedalmate.data.datasource.remote.member.HistoryRecruitList
+import androidx.paging.PagingData
+import com.mate.baedalmate.data.datasource.remote.member.HistoryRecruitResponseDto
 import com.mate.baedalmate.data.datasource.remote.member.MemberOAuthRequest
 import com.mate.baedalmate.data.datasource.remote.member.MemberOAuthResponse
 import com.mate.baedalmate.data.datasource.remote.member.ResultSuccessResponseDto
 import com.mate.baedalmate.data.datasource.remote.member.UserInfoResponse
 import com.mate.baedalmate.domain.model.ApiResult
 import com.mate.baedalmate.domain.model.Dormitory
-import com.mate.baedalmate.domain.model.UpdateUserDto
+import kotlinx.coroutines.flow.Flow
 import okhttp3.MultipartBody
 
 interface MemberRepository {
     suspend fun requestLoginKakao(body: MemberOAuthRequest): ApiResult<MemberOAuthResponse>
     suspend fun requestGetUserInfo(): ApiResult<UserInfoResponse>
     suspend fun requestPutUserDormitory(newDormitory: Dormitory): ApiResult<ResultSuccessResponseDto>
-    suspend fun requestPostChangeMyProfile(isChangingDefaultImage: Boolean, newNickname: String, uploadfile: MultipartBody.Part?): ApiResult<UserInfoResponse>    suspend fun requestGetHistoryPostCreated(
-        page: Int,
-        size: Int,
-        sort: String
-    ): ApiResult<HistoryRecruitList>
-    suspend fun requestGetHistoryPostParticipated(
-        page: Int,
-        size: Int,
-        sort: String
-    ): ApiResult<HistoryRecruitList>
+    suspend fun requestPostChangeMyProfile(isChangingDefaultImage: Boolean, newNickname: String, uploadfile: MultipartBody.Part?): ApiResult<UserInfoResponse>
+    suspend fun requestGetHistoryPostCreated(sort: String): Flow<PagingData<HistoryRecruitResponseDto>>
+    suspend fun requestGetHistoryPostParticipated(sort: String): Flow<PagingData<HistoryRecruitResponseDto>>
     suspend fun requestPostLogout(): ApiResult<ResultSuccessResponseDto>
     suspend fun requestDeleteResignUser(): ApiResult<ResultSuccessResponseDto>
 }

--- a/app/src/main/java/com/mate/baedalmate/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/repository/SearchRepository.kt
@@ -1,13 +1,12 @@
 package com.mate.baedalmate.domain.repository
 
-import com.mate.baedalmate.domain.model.ApiResult
-import com.mate.baedalmate.domain.model.RecruitList
+import androidx.paging.PagingData
+import com.mate.baedalmate.domain.model.RecruitDto
+import kotlinx.coroutines.flow.Flow
 
 interface SearchRepository {
     suspend fun requestGetSearchTagKeyword(
         keyword: String,
-        page: Int,
-        size: Int,
         sort: String
-    ): ApiResult<RecruitList>
+    ): Flow<PagingData<RecruitDto>>
 }

--- a/app/src/main/java/com/mate/baedalmate/domain/usecase/member/RequestGetHistoryPostCreatedUseCase.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/usecase/member/RequestGetHistoryPostCreatedUseCase.kt
@@ -1,15 +1,13 @@
 package com.mate.baedalmate.domain.usecase.member
 
 import com.mate.baedalmate.domain.repository.MemberRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class RequestGetHistoryPostCreatedUseCase @Inject constructor(private val memberRepository: MemberRepository) {
-    suspend operator fun invoke(page: Int, size: Int, sort: String) =
-        memberRepository.requestGetHistoryPostCreated(
-            page = page,
-            size = size,
-            sort = sort
-        )
+    suspend operator fun invoke(sort: String) =
+        memberRepository.requestGetHistoryPostCreated(sort = sort).flowOn(Dispatchers.Default)
 }

--- a/app/src/main/java/com/mate/baedalmate/domain/usecase/member/RequestGetHistoryPostParticipatedUseCase.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/usecase/member/RequestGetHistoryPostParticipatedUseCase.kt
@@ -1,15 +1,13 @@
 package com.mate.baedalmate.domain.usecase.member
 
 import com.mate.baedalmate.domain.repository.MemberRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class RequestGetHistoryPostParticipatedUseCase @Inject constructor(private val memberRepository: MemberRepository) {
-    suspend operator fun invoke(page: Int, size: Int, sort: String) =
-        memberRepository.requestGetHistoryPostParticipated(
-            page = page,
-            size = size,
-            sort = sort
-        )
+    suspend operator fun invoke(sort: String) =
+        memberRepository.requestGetHistoryPostParticipated(sort = sort).flowOn(Dispatchers.Default)
 }

--- a/app/src/main/java/com/mate/baedalmate/domain/usecase/search/RequestGetSearchTagKeywordUseCase.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/usecase/search/RequestGetSearchTagKeywordUseCase.kt
@@ -6,11 +6,6 @@ import javax.inject.Singleton
 
 @Singleton
 class RequestGetSearchTagKeywordUseCase @Inject constructor(private val searchRepository: SearchRepository) {
-    suspend operator fun invoke(keyword:String, page: Int, size: Int, sort: String) =
-        searchRepository.requestGetSearchTagKeyword(
-            keyword = keyword,
-            page = page,
-            size = size,
-            sort = sort
-        )
+    suspend operator fun invoke(keyword: String, sort: String) =
+        searchRepository.requestGetSearchTagKeyword(keyword = keyword, sort = sort)
 }

--- a/app/src/main/java/com/mate/baedalmate/presentation/adapter/history/HistoryPostAdapter.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/adapter/history/HistoryPostAdapter.kt
@@ -2,8 +2,8 @@ package com.mate.baedalmate.presentation.adapter.history
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Priority
 import com.bumptech.glide.RequestManager
@@ -15,7 +15,9 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 class HistoryPostAdapter(private val requestManager: RequestManager) :
-    ListAdapter<HistoryRecruitResponseDto, HistoryPostAdapter.HistoryPostViewHolder>(diffCallback) {
+    PagingDataAdapter<HistoryRecruitResponseDto, HistoryPostAdapter.HistoryPostViewHolder>(
+        diffCallback
+    ) {
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<HistoryRecruitResponseDto>() {
             override fun areItemsTheSame(
@@ -51,13 +53,10 @@ class HistoryPostAdapter(private val requestManager: RequestManager) :
         )
 
     override fun onBindViewHolder(
-        holder: HistoryPostAdapter.HistoryPostViewHolder, position: Int,
+        holder: HistoryPostAdapter.HistoryPostViewHolder,
+        position: Int,
     ) {
-        holder.bind(getItem(position))
-    }
-
-    override fun submitList(list: MutableList<HistoryRecruitResponseDto>?) {
-        super.submitList(list?.let { ArrayList(it) })
+        getItem(position)?.let { holder.bind(it) }
     }
 
     inner class HistoryPostViewHolder(private val binding: ItemHistoryPostBinding) :


### PR DESCRIPTION
## 내용및 작업사항
- 모집글이 나타나는 Fragment들에 대해 무한 스크롤 구현
   - 마이페이지에서 연결되는 내가 참여한 모집글 페이지와, 주최한 모집글 페이지에 대한 무한스크롤 구현
   - 검색 결과에 대한 무한스크롤 구현

## 참고
- 검색 결과에 대한 게시글의 총 개수를 클라이언트단에서 알 수 없게됨에 따라, 서버에서 해당 정보를 받아와야함. 추후 이에 대해 구현 예정
- #196 