### PR TITLE
#206 [feature] Shows Search Result Post Count

### DIFF
--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/search/SearchApiService.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/search/SearchApiService.kt
@@ -1,6 +1,5 @@
 package com.mate.baedalmate.data.datasource.remote.search
 
-import com.mate.baedalmate.domain.model.RecruitList
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -12,5 +11,5 @@ interface SearchApiService {
         @Query("page") page: Int,
         @Query("size") size: Int,
         @Query("sort") sort: String,
-    ): Response<RecruitList>
+    ): Response<SearchRecruitList>
 }

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/search/SearchResponse.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/search/SearchResponse.kt
@@ -1,0 +1,13 @@
+package com.mate.baedalmate.data.datasource.remote.search
+
+import com.google.gson.annotations.SerializedName
+import com.mate.baedalmate.domain.model.RecruitDto
+
+data class SearchRecruitList (
+    @SerializedName("recruitList")
+    val recruitList: List<RecruitDto>,
+    @SerializedName("total")
+    val total: Int,
+    @SerializedName("last")
+    val last: Boolean
+)

--- a/app/src/main/java/com/mate/baedalmate/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/repository/SearchRepositoryImpl.kt
@@ -15,7 +15,7 @@ class SearchRepositoryImpl @Inject constructor(private val searchApiService: Sea
     override suspend fun requestGetSearchTagKeyword(
         keyword: String,
         sort: String
-    ): Flow<PagingData<RecruitDto>> = Pager(
+    ): Flow<PagingData<Pair<RecruitDto, Int>>> = Pager(
         config = PagingConfig(pageSize = 6, maxSize = 30, enablePlaceholders = false),
         pagingSourceFactory = { PostSearchResultPagingSource(searchApiService, keyword, sort) }
     ).flow

--- a/app/src/main/java/com/mate/baedalmate/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/repository/SearchRepository.kt
@@ -8,5 +8,5 @@ interface SearchRepository {
     suspend fun requestGetSearchTagKeyword(
         keyword: String,
         sort: String
-    ): Flow<PagingData<RecruitDto>>
+    ): Flow<PagingData<Pair<RecruitDto, Int>>>
 }

--- a/app/src/main/java/com/mate/baedalmate/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/viewmodel/SearchViewModel.kt
@@ -17,7 +17,7 @@ import javax.inject.Inject
 class SearchViewModel @Inject constructor(
     private val requestGetSearchTagKeywordUseCase: RequestGetSearchTagKeywordUseCase
 ) : ViewModel() {
-    private val _searchKeywordResults = MutableStateFlow<PagingData<RecruitDto>>(PagingData.empty())
+    private val _searchKeywordResults = MutableStateFlow<PagingData<Pair<RecruitDto, Int>>>(PagingData.empty())
     val searchKeywordResults = _searchKeywordResults.asStateFlow()
 
     fun requestSearchKeywordResult(
@@ -27,8 +27,8 @@ class SearchViewModel @Inject constructor(
         requestGetSearchTagKeywordUseCase(
             keyword = keyword,
             sort = sort
-        ).cachedIn(viewModelScope).collectLatest { searchResultLit ->
-            _searchKeywordResults.emit(searchResultLit)
+        ).cachedIn(viewModelScope).collectLatest { searchResult ->
+            _searchKeywordResults.emit(searchResult)
         }
     }
 


### PR DESCRIPTION
## 내용및 작업사항
- 태그 검색해 나온 모집글들에 대한 총 갯수를 보여주도록 구현
   - [`Paging3` 에서 Meta-data를 넘기는 것이 구현되지 않음](https://issuetracker.google.com/issues/175338415)에 따라, 리스트의 모든 아이템에 검색결과의 총 갯수를 함께 담아서 넘기는 것으로 우회해 구현
   - 위의 이유로 기존에 `RecruitDto`만 넘기던 것에서 `Pair`로 변경됨에 따라 영향 받는 코드들에 대한 수정

## 참고
- resolved: #206