### PR TITLE
#208 [feature] Create TakePhoto, Reset profile image

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,15 @@
         <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
         <!-- Enable user interaction tracing to capture transactions for various UI events (such as clicks or scrolls). -->
         <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.mate.baedalmate.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
 
         <activity
             android:name=".presentation.activity.LoginActivity"

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/mypage/MyPageFragment.kt
@@ -102,6 +102,9 @@ class MyPageFragment : Fragment() {
     }
 
     private fun setUserInfoClickListener() {
+        binding.layoutMyPageUserInfo.setOnDebounceClickListener {
+            findNavController().navigate(R.id.action_myPageFragment_to_myProfileChangeFragment)
+        }
         binding.tvMyPageUserInfoHistoryParticipated.setOnDebounceClickListener {
             findNavController().navigate(R.id.action_myPageFragment_to_historyPostParticipatedFragment)
         }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/profile/MyProfileChangeImageOptionFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/profile/MyProfileChangeImageOptionFragment.kt
@@ -1,0 +1,198 @@
+package com.mate.baedalmate.presentation.fragment.profile
+
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.MediaStore
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
+import androidx.core.content.FileProvider
+import androidx.fragment.app.DialogFragment
+import androidx.navigation.fragment.findNavController
+import com.mate.baedalmate.BuildConfig
+import com.mate.baedalmate.common.GetDeviceSize
+import com.mate.baedalmate.common.autoCleared
+import com.mate.baedalmate.common.extension.setOnDebounceClickListener
+import com.mate.baedalmate.databinding.FragmentMyProfileChangeImageOptionBinding
+import dagger.hilt.android.AndroidEntryPoint
+import java.io.File
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.Objects
+
+@AndroidEntryPoint
+class MyProfileChangeImageOptionFragment : DialogFragment() {
+    private var binding by autoCleared<FragmentMyProfileChangeImageOptionBinding>()
+    private lateinit var currentTakenPhotoPath: String
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentMyProfileChangeImageOptionBinding.inflate(inflater, container, false)
+        initDialogFragmentLayout()
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setCameraClickListener()
+        setGalleryClickListener()
+        setResetClickListener()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        resizeOptionDialogFragment()
+    }
+
+    private fun initDialogFragmentLayout() {
+        requireDialog().window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        requireDialog().window?.requestFeature(Window.FEATURE_NO_TITLE)
+        requireDialog().window?.setGravity(Gravity.BOTTOM)
+    }
+
+    private fun resizeOptionDialogFragment() {
+        val params: ViewGroup.LayoutParams? = dialog?.window?.attributes
+        val deviceWidth = GetDeviceSize.getDeviceWidthSize(requireContext())
+        params?.width = (deviceWidth * 0.9).toInt()
+        dialog?.window?.attributes = params as WindowManager.LayoutParams
+    }
+
+    private fun setCameraClickListener() {
+        binding.layoutMyProfileChangeOptionSelectCamera.setOnDebounceClickListener {
+            requestOpenCamera.launch(
+                arrayOf(
+                    Manifest.permission.CAMERA,
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+                )
+            )
+        }
+    }
+
+    private fun setGalleryClickListener() {
+        binding.layoutMyProfileChangeOptionSelectGallery.setOnDebounceClickListener {
+            requestOpenGallery.launch(
+                arrayOf(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+                )
+            )
+        }
+    }
+
+    private fun setResetClickListener() {
+        binding.layoutMyProfileChangeOptionSelectReset.setOnDebounceClickListener {
+            setMyProfileImage("resetMyProfileImage", "")
+        }
+    }
+
+    private val requestOpenCamera =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            permissions.entries.forEach {
+                if (it.value == false) {
+                    return@registerForActivityResult
+                }
+            }
+            openCamera()
+        }
+
+    private fun openCamera() {
+        val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        if (intent.resolveActivity(requireContext().packageManager) != null) {
+            var photoFile: File? = null
+            val tmpDir: File? = requireContext().cacheDir
+            val timeStamp: String =
+                SimpleDateFormat("yyyy-MM-d-HH-mm-ss", Locale.KOREA).format(Date())
+            val photoFileName = "Capture_${timeStamp}_"
+            try {
+                val tmpPhoto = File.createTempFile(photoFileName, ".jpg", tmpDir)
+                currentTakenPhotoPath = tmpPhoto.absolutePath
+                photoFile = tmpPhoto
+            } catch (e: IOException) {
+                e.printStackTrace()
+            }
+            if (photoFile != null) {
+                val photoURI = FileProvider.getUriForFile(
+                    Objects.requireNonNull(requireContext().applicationContext),
+                    BuildConfig.APPLICATION_ID + ".fileprovider",
+                    photoFile
+                )
+                intent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI)
+                requestTakePhotoActivity.launch(intent)
+            }
+        }
+    }
+
+    private val requestOpenGallery =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            permissions.entries.forEach {
+                if (it.value == false) {
+                    return@registerForActivityResult
+                }
+            }
+            openGallery()
+        }
+
+    private fun openGallery() {
+        // ACTION PICK 사용시, intent type에서 설정한 종류의 데이터를 MediaStore에서 불러와서 목록으로 나열 후 선택할 수 있는 앱 실행
+        val intent = Intent(Intent.ACTION_PICK)
+        intent.type = MediaStore.Images.Media.CONTENT_TYPE
+        requestActivity.launch(intent)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    val requestActivity =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { activityResult ->
+            if (activityResult.resultCode == Activity.RESULT_OK) {
+                val data: Intent? = activityResult.data
+                // 호출된 갤러리에서 이미지 선택시, data의 data속성으로 해당 이미지의 Uri 전달
+                val uri = data?.data!!
+                // 이미지 파일과 함께, 파일 확장자도 같이 저장
+                val fileExtension =
+                    requireContext().contentResolver.getType(uri).toString().split("/")[1]
+                setMyProfileImage(uri.toString(), fileExtension)
+            } else {
+                findNavController().popBackStack()
+            }
+        }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    val requestTakePhotoActivity =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { activityResult ->
+            if (activityResult.resultCode == Activity.RESULT_OK) {
+                val photoFile = File(currentTakenPhotoPath)
+                // 이미지 파일과 함께, 파일 확장자도 같이 저장
+                val fileExtension = Uri.fromFile(photoFile).toString().split("/")[1]
+                setMyProfileImage(Uri.fromFile(photoFile).toString(), fileExtension)
+            } else {
+                findNavController().popBackStack()
+            }
+        }
+
+    private fun setMyProfileImage(ImageString: String, fileExtension: String) {
+        findNavController().previousBackStackEntry?.savedStateHandle?.set(
+            "userProfileImageString",
+            ImageString
+        )
+        findNavController().previousBackStackEntry?.savedStateHandle?.set(
+            "fileExtension",
+            fileExtension
+        )
+        findNavController().popBackStack()
+    }
+}

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/setAccount/SetAccountMyProfileImageOptionFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/setAccount/SetAccountMyProfileImageOptionFragment.kt
@@ -1,0 +1,191 @@
+package com.mate.baedalmate.presentation.fragment.setAccount
+
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.MediaStore
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
+import androidx.core.content.FileProvider
+import androidx.fragment.app.DialogFragment
+import androidx.navigation.fragment.findNavController
+import com.mate.baedalmate.BuildConfig
+import com.mate.baedalmate.common.GetDeviceSize
+import com.mate.baedalmate.common.autoCleared
+import com.mate.baedalmate.common.extension.setOnDebounceClickListener
+import com.mate.baedalmate.databinding.FragmentSetAccountMyProfileImageOptionBinding
+import dagger.hilt.android.AndroidEntryPoint
+import java.io.File
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.Objects
+
+@AndroidEntryPoint
+class SetAccountMyProfileImageOptionFragment : DialogFragment() {
+    private var binding by autoCleared<FragmentSetAccountMyProfileImageOptionBinding>()
+    private lateinit var currentTakenPhotoPath: String
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentSetAccountMyProfileImageOptionBinding.inflate(inflater, container, false)
+        initDialogFragmentLayout()
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setCameraClickListener()
+        setGalleryClickListener()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        resizeOptionDialogFragment()
+    }
+
+    private fun initDialogFragmentLayout() {
+        requireDialog().window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        requireDialog().window?.requestFeature(Window.FEATURE_NO_TITLE)
+        requireDialog().window?.setGravity(Gravity.BOTTOM)
+    }
+
+    private fun resizeOptionDialogFragment() {
+        val params: ViewGroup.LayoutParams? = dialog?.window?.attributes
+        val deviceWidth = GetDeviceSize.getDeviceWidthSize(requireContext())
+        params?.width = (deviceWidth * 0.9).toInt()
+        dialog?.window?.attributes = params as WindowManager.LayoutParams
+    }
+
+    private fun setCameraClickListener() {
+        binding.layoutSetAccountMyProfileChangeOptionSelectCamera.setOnDebounceClickListener {
+            requestOpenCamera.launch(
+                arrayOf(
+                    Manifest.permission.CAMERA,
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+                )
+            )
+        }
+    }
+
+    private fun setGalleryClickListener() {
+        binding.layoutSetAccountMyProfileChangeOptionSelectGallery.setOnDebounceClickListener {
+            requestOpenGallery.launch(
+                arrayOf(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+                )
+            )
+        }
+    }
+
+    private val requestOpenCamera =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            permissions.entries.forEach {
+                if (it.value == false) {
+                    return@registerForActivityResult
+                }
+            }
+            openCamera()
+        }
+
+    private fun openCamera() {
+        val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        if (intent.resolveActivity(requireContext().packageManager) != null) {
+            var photoFile: File? = null
+            val tmpDir: File? = requireContext().cacheDir
+            val timeStamp: String =
+                SimpleDateFormat("yyyy-MM-d-HH-mm-ss", Locale.KOREA).format(Date())
+            val photoFileName = "Capture_${timeStamp}_"
+            try {
+                val tmpPhoto = File.createTempFile(photoFileName, ".jpg", tmpDir)
+                currentTakenPhotoPath = tmpPhoto.absolutePath
+                photoFile = tmpPhoto
+            } catch (e: IOException) {
+                e.printStackTrace()
+            }
+            if (photoFile != null) {
+                val photoURI = FileProvider.getUriForFile(
+                    Objects.requireNonNull(requireContext().applicationContext),
+                    BuildConfig.APPLICATION_ID + ".fileprovider",
+                    photoFile
+                )
+                intent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI)
+                requestTakePhotoActivity.launch(intent)
+            }
+        }
+    }
+
+    private val requestOpenGallery =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            permissions.entries.forEach {
+                if (it.value == false) {
+                    return@registerForActivityResult
+                }
+            }
+            openGallery()
+        }
+
+    private fun openGallery() {
+        // ACTION PICK 사용시, intent type에서 설정한 종류의 데이터를 MediaStore에서 불러와서 목록으로 나열 후 선택할 수 있는 앱 실행
+        val intent = Intent(Intent.ACTION_PICK)
+        intent.type = MediaStore.Images.Media.CONTENT_TYPE
+        requestActivity.launch(intent)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    val requestActivity =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { activityResult ->
+            if (activityResult.resultCode == Activity.RESULT_OK) {
+                val data: Intent? = activityResult.data
+                // 호출된 갤러리에서 이미지 선택시, data의 data속성으로 해당 이미지의 Uri 전달
+                val uri = data?.data!!
+                // 이미지 파일과 함께, 파일 확장자도 같이 저장
+                val fileExtension =
+                    requireContext().contentResolver.getType(uri).toString().split("/")[1]
+                setMyProfileImage(uri.toString(), fileExtension)
+            } else {
+                findNavController().popBackStack()
+            }
+        }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    val requestTakePhotoActivity =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { activityResult ->
+            if (activityResult.resultCode == Activity.RESULT_OK) {
+                val photoFile = File(currentTakenPhotoPath)
+                // 이미지 파일과 함께, 파일 확장자도 같이 저장
+                val fileExtension = Uri.fromFile(photoFile).toString().split("/")[1]
+                setMyProfileImage(Uri.fromFile(photoFile).toString(), fileExtension)
+            } else {
+                findNavController().popBackStack()
+            }
+        }
+
+    private fun setMyProfileImage(ImageString: String, fileExtension: String) {
+        findNavController().previousBackStackEntry?.savedStateHandle?.set(
+            "userProfileImageString",
+            ImageString
+        )
+        findNavController().previousBackStackEntry?.savedStateHandle?.set(
+            "fileExtension",
+            fileExtension
+        )
+        findNavController().popBackStack()
+    }
+}

--- a/app/src/main/res/drawable/selector_btn_gray_line_white_radius_10_mid.xml
+++ b/app/src/main/res/drawable/selector_btn_gray_line_white_radius_10_mid.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gray_line_EBEBEB" />
+        </shape>
+    </item>
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gray_line_EBEBEB" />
+        </shape>
+    </item>
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gray_line_EBEBEB" />
+        </shape>
+    </item>
+    <item android:state_checked="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gray_line_EBEBEB" />
+        </shape>
+    </item>
+    <item android:state_checked="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white_FFFFFF" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -43,7 +43,7 @@
             app:layout_constraintTop_toBottomOf="@id/layout_my_page_actionbar">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/layout_my_page_user_info"
+                android:id="@+id/layout_my_page_user_info_background"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="15dp"
@@ -52,7 +52,6 @@
                 android:backgroundTint="@color/main_FB5F1C"
                 android:paddingHorizontal="15dp"
                 android:paddingTop="15dp"
-                android:paddingBottom="13dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
@@ -60,126 +59,138 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintVertical_bias="0.0">
 
-                <com.google.android.material.imageview.ShapeableImageView
-                    android:id="@+id/img_my_page_user_info"
-                    android:layout_width="55dp"
-                    android:layout_height="55dp"
-                    android:layout_marginStart="5dp"
-                    android:src="@color/gray_main_C4C4C4"
+                <LinearLayout
+                    android:id="@+id/layout_my_page_user_info"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintDimensionRatio="W,1:1"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintVertical_bias="0.0"
-                    app:shapeAppearanceOverlay="@style/roundImageView" />
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/layout_my_page_user_info_detail"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="15dp"
-                    android:gravity="center_horizontal"
-                    android:orientation="vertical"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="0.0"
-                    app:layout_constraintStart_toEndOf="@id/img_my_page_user_info"
-                    app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintVertical_bias="0.0">
 
-                    <TextView
-                        android:id="@+id/tv_my_page_user_info_nickname"
-                        style="@style/style_title1_kor"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="@font/applesdgothic_neo_medium"
-                        android:gravity="center_vertical"
-                        android:textColor="@color/white_FFFFFF"
+                    <com.google.android.material.imageview.ShapeableImageView
+                        android:id="@+id/img_my_page_user_info"
+                        android:layout_width="55dp"
+                        android:layout_height="55dp"
+                        android:layout_marginStart="5dp"
+                        android:src="@color/gray_main_C4C4C4"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toStartOf="@id/layout_my_page_user_info_score"
+                        app:layout_constraintDimensionRatio="W,1:1"
+                        app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintHorizontal_bias="0.0"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
                         app:layout_constraintVertical_bias="0.0"
-                        tools:text="사용자 이름" />
+                        app:shapeAppearanceOverlay="@style/roundImageView" />
 
-                    <LinearLayout
-                        android:id="@+id/layout_my_page_user_info_dormitory"
-                        android:layout_width="wrap_content"
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/layout_my_page_user_info_detail"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="13dp"
-                        android:orientation="horizontal"
+                        android:layout_marginStart="15dp"
+                        android:gravity="center_horizontal"
+                        android:orientation="vertical"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintHorizontal_bias="0.0"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/tv_my_page_user_info_nickname"
-                        app:layout_constraintVertical_bias="0.0">
-
-                        <TextView
-                            style="@style/style_caption1_kor"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:background="@drawable/background_white_radius_30"
-                            android:gravity="center"
-                            android:paddingHorizontal="8dp"
-                            android:paddingVertical="5dp"
-                            android:text="@string/current_location"
-                            android:textColor="@color/gray_dark_666666" />
-
-                        <TextView
-                            android:id="@+id/tv_my_page_user_info_dormitory"
-                            style="@style/style_semi_title_kor"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="12dp"
-                            android:gravity="bottom"
-                            android:textColor="@color/white_FFFFFF"
-                            tools:text="성림학사" />
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:id="@+id/layout_my_page_user_info_score"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintHorizontal_bias="1.0"
+                        app:layout_constraintStart_toEndOf="@id/img_my_page_user_info"
                         app:layout_constraintTop_toTopOf="parent"
                         app:layout_constraintVertical_bias="0.0">
 
-                        <ImageView
-                            android:layout_width="15dp"
-                            android:layout_height="15dp"
-                            android:scaleType="fitXY"
-                            android:src="@drawable/ic_star"
-                            app:tint="@color/white_FFFFFF" />
-
                         <TextView
-                            android:id="@+id/tv_my_page_user_info_score"
-                            style="@style/style_semi_title_kor"
-                            android:layout_width="wrap_content"
-                            android:layout_height="match_parent"
-                            android:layout_marginStart="8dp"
+                            android:id="@+id/tv_my_page_user_info_nickname"
+                            style="@style/style_title1_kor"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/applesdgothic_neo_medium"
+                            android:gravity="center_vertical"
                             android:textColor="@color/white_FFFFFF"
-                            tools:text="4.2" />
-                    </LinearLayout>
-                </androidx.constraintlayout.widget.ConstraintLayout>
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/layout_my_page_user_info_score"
+                            app:layout_constraintHorizontal_bias="0.0"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintVertical_bias="0.0"
+                            tools:text="사용자 이름" />
+
+                        <LinearLayout
+                            android:id="@+id/layout_my_page_user_info_dormitory"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="13dp"
+                            android:orientation="horizontal"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintHorizontal_bias="0.0"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toBottomOf="@id/tv_my_page_user_info_nickname"
+                            app:layout_constraintVertical_bias="0.0">
+
+                            <TextView
+                                style="@style/style_caption1_kor"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:background="@drawable/background_white_radius_30"
+                                android:gravity="center"
+                                android:paddingHorizontal="8dp"
+                                android:paddingVertical="5dp"
+                                android:text="@string/current_location"
+                                android:textColor="@color/gray_dark_666666" />
+
+                            <TextView
+                                android:id="@+id/tv_my_page_user_info_dormitory"
+                                style="@style/style_semi_title_kor"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="12dp"
+                                android:gravity="bottom"
+                                android:textColor="@color/white_FFFFFF"
+                                tools:text="성림학사" />
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:id="@+id/layout_my_page_user_info_score"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintHorizontal_bias="1.0"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintVertical_bias="0.0">
+
+                            <ImageView
+                                android:layout_width="15dp"
+                                android:layout_height="15dp"
+                                android:scaleType="fitXY"
+                                android:src="@drawable/ic_star"
+                                app:tint="@color/white_FFFFFF" />
+
+                            <TextView
+                                android:id="@+id/tv_my_page_user_info_score"
+                                style="@style/style_semi_title_kor"
+                                android:layout_width="wrap_content"
+                                android:layout_height="match_parent"
+                                android:layout_marginStart="8dp"
+                                android:textColor="@color/white_FFFFFF"
+                                tools:text="4.2" />
+                        </LinearLayout>
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </LinearLayout>
 
                 <LinearLayout
                     android:id="@+id/layout_my_page_user_info_history"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="18dp"
                     android:gravity="center"
                     android:orientation="horizontal"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/layout_my_page_user_info_detail">
+                    app:layout_constraintTop_toBottomOf="@id/layout_my_page_user_info">
 
                     <TextView
                         android:id="@+id/tv_my_page_user_info_history_participated"
@@ -188,12 +199,16 @@
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
                         android:gravity="center"
+                        android:paddingTop="18dp"
+                        android:paddingBottom="13dp"
                         android:text="@string/my_page_user_info_history_participated"
                         android:textColor="@color/white_FFFFFF" />
 
                     <View
                         android:layout_width="1dp"
                         android:layout_height="match_parent"
+                        android:layout_marginTop="18dp"
+                        android:layout_marginBottom="13dp"
                         android:background="@color/white_FFFFFF" />
 
                     <TextView
@@ -203,6 +218,8 @@
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
                         android:gravity="center"
+                        android:paddingTop="18dp"
+                        android:paddingBottom="13dp"
                         android:text="@string/my_page_user_info_history_created"
                         android:textColor="@color/white_FFFFFF" />
                 </LinearLayout>
@@ -219,7 +236,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layout_my_page_user_info"
+                app:layout_constraintTop_toBottomOf="@id/layout_my_page_user_info_background"
                 app:layout_constraintVertical_bias="0.0">
 
                 <LinearLayout

--- a/app/src/main/res/layout/fragment_my_profile_change_image_option.xml
+++ b/app/src/main/res/layout/fragment_my_profile_change_image_option.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="16dp"
+    tools:context=".presentation.fragment.profile.MyProfileChangeImageOptionFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_my_profile_change_option_select_camera"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/selector_btn_gray_line_white_radius_10_top"
+        android:paddingHorizontal="15dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_my_profile_change_option_select_camera"
+            style="@style/style_body1_kor"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="21dp"
+            android:layout_marginBottom="17dp"
+            android:text="@string/select_photo_method_take_photo"
+            android:textColor="@color/black_000000"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <LinearLayout
+        android:id="@+id/layout_my_profile_change_option_camera_gallery_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/white_FFFFFF"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_my_profile_change_option_select_camera">
+
+        <View
+            android:id="@+id/view_my_profile_change_option_camera_gallery_divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginHorizontal="10dp"
+            android:background="@color/gray_line_EBEBEB" />
+    </LinearLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_my_profile_change_option_select_gallery"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/selector_btn_gray_line_white_radius_10_mid"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_my_profile_change_option_camera_gallery_divider">
+
+        <TextView
+            android:id="@+id/tv_my_profile_change_option_select_gallery"
+            style="@style/style_body1_kor"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="17dp"
+            android:text="@string/select_photo_method_gallery"
+            android:textColor="@color/black_000000"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <LinearLayout
+        android:id="@+id/layout_my_profile_change_option_gallery_reset_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/white_FFFFFF"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_my_profile_change_option_select_gallery">
+
+        <View
+            android:id="@+id/view_my_profile_change_option_gallery_reset_divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginHorizontal="10dp"
+            android:background="@color/gray_line_EBEBEB" />
+    </LinearLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_my_profile_change_option_select_reset"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/selector_btn_gray_line_white_radius_10_bottom"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_my_profile_change_option_gallery_reset_divider">
+
+        <TextView
+            android:id="@+id/tv_my_profile_change_option_select_reset"
+            style="@style/style_body1_kor"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="17dp"
+            android:text="@string/select_photo_method_reset"
+            android:textColor="@color/black_000000"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_set_account_my_profile_image_option.xml
+++ b/app/src/main/res/layout/fragment_set_account_my_profile_image_option.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="16dp"
+    tools:context=".presentation.fragment.setAccount.SetAccountMyProfileImageOptionFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_set_account_my_profile_change_option_select_camera"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/selector_btn_gray_line_white_radius_10_top"
+        android:paddingHorizontal="15dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_set_account_my_profile_change_option_select_camera"
+            style="@style/style_body1_kor"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="21dp"
+            android:layout_marginBottom="17dp"
+            android:text="@string/select_photo_method_take_photo"
+            android:textColor="@color/black_000000"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <LinearLayout
+        android:id="@+id/layout_set_account_my_profile_change_option_camera_gallery_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/white_FFFFFF"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_set_account_my_profile_change_option_select_camera">
+
+        <View
+            android:id="@+id/view_set_account_my_profile_change_option_camera_gallery_divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginHorizontal="10dp"
+            android:background="@color/gray_line_EBEBEB" />
+    </LinearLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_set_account_my_profile_change_option_select_gallery"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/selector_btn_gray_line_white_radius_10_bottom"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layout_set_account_my_profile_change_option_camera_gallery_divider">
+
+        <TextView
+            android:id="@+id/tv_set_account_my_profile_change_option_select_gallery"
+            style="@style/style_body1_kor"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="17dp"
+            android:text="@string/select_photo_method_gallery"
+            android:textColor="@color/black_000000"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -510,7 +510,16 @@
         android:id="@+id/MyProfileChangeFragment"
         android:name="com.mate.baedalmate.presentation.fragment.profile.MyProfileChangeFragment"
         android:label="fragment_my_profile_change"
-        tools:layout="@layout/fragment_my_profile_change" />
+        tools:layout="@layout/fragment_my_profile_change">
+        <action
+            android:id="@+id/action_myProfileChangeFragment_to_myProfileChangeOptionFragment"
+            app:destination="@id/MyProfileChangeImageOptionFragment" />
+    </fragment>
+    <dialog
+        android:id="@+id/MyProfileChangeImageOptionFragment"
+        android:name="com.mate.baedalmate.presentation.fragment.profile.MyProfileChangeImageOptionFragment"
+        android:label="fragment_my_profile_change_image_option"
+        tools:layout="@layout/fragment_my_profile_change_image_option" />
 
     <fragment
         android:id="@+id/LocationCertificationFragment"

--- a/app/src/main/res/navigation/nav_graph_login.xml
+++ b/app/src/main/res/navigation/nav_graph_login.xml
@@ -55,7 +55,16 @@
             app:popExitAnim="@anim/slide_to_right"
             app:popUpTo="@id/SetAccountMyProfileFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_setAccountMyProfileFragment_to_setAccountMyProfileImageOptionFragment"
+            app:destination="@id/SetAccountMyProfileImageOptionFragment" />
     </fragment>
+
+    <dialog
+        android:id="@+id/SetAccountMyProfileImageOptionFragment"
+        android:name="com.mate.baedalmate.presentation.fragment.setAccount.SetAccountMyProfileImageOptionFragment"
+        android:label="fragment_set_account_my_profile_image_option"
+        tools:layout="@layout/fragment_set_account_my_profile_image_option" />
 
     <fragment
         android:id="@+id/LocationCertificationFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,11 @@
     <string name="category_asia">아시안</string>
     <string name="category_packedmeal">도시락</string>
 
+    <!-- Select Photo method -->
+    <string name="select_photo_method_take_photo">카메라로 찍기</string>
+    <string name="select_photo_method_gallery">앨범에서 선택</string>
+    <string name="select_photo_method_reset">기본 이미지로 설정</string>
+
     <!-- login -->
     <string name="login_select_method_kakao">카카오톡으로 시작하기</string>
     <string name="login_policy_guide_message">가입 시 배달메이트의 이용약관및 개인정보취급방침에 동의하게 됩니다.</string>
@@ -349,6 +354,8 @@
     <!-- Update -->
     <string name="update_dialog_title">업데이트</string>
     <string name="update_dialog_description">업데이트가 필요합니다</string>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 
     <!-- Participant Profile -->
 </resources>

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path
+        name="cache"
+        path="."/>
+    <files-path
+        name="Capture"
+        path="."/>
+    <external-path
+        name="external"
+        path="."/>
+    <external-cache-path
+        name="external-cache"
+        path="."/>
+    <external-files-path
+        name="external-files"
+        path="."/>
+</paths>


### PR DESCRIPTION
## 내용및 작업사항
- 기존 계정 프로필 수정시에 카메라로 직접 촬영 및, 프로필 초기화 기능 구현
- 초기 계정 설정시에 카메라로 직접 촬영 기능 구현
- 프로필 사진 설정 방법 선택 구현을 위해 기존 프로필 사진을 누르면 갤러리로 넘어가던 방식에서 새로운 Dialog를 띄워 사진 선택방법을 보여주는 것으로 플로우 변경 및 관련 레이아웃및 기능 구현
- 카메라로 직접 촬영 기능 구현을 위해 `AndroidManifest`에 `Provider` 추가 및 `filepaths `xml 파일 추가
- MyPage에서 상단 프로필을 클릭했을 때에도 프로필 변경 Fragment로 이동할 수 있도록 동작 추가 및 관련 레이아웃 구조 일부 변경

## 참고
- resolved: #208