### PR TITLE
#214 [feature] Create Notification Feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA"/>
@@ -34,6 +35,28 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/filepaths" />
         </provider>
+        <service
+            android:name="com.mate.baedalmate.data.datasource.remote.firebase.FirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_baedal_mate_foreground" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/white_FFFFFF" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="@string/notification_channel_default_id" />
+        <!-- FCM: Disable auto-init -->
+        <meta-data android:name="firebase_messaging_auto_init_enabled"
+            android:value="false" />
+        <meta-data android:name="firebase_analytics_collection_enabled"
+            android:value="false" />
 
         <activity
             android:name=".presentation.activity.LoginActivity"

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/firebase/FirebaseMessagingService.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/firebase/FirebaseMessagingService.kt
@@ -1,0 +1,239 @@
+package com.mate.baedalmate.data.datasource.remote.firebase
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.media.RingtoneManager
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.bumptech.glide.Glide
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.google.firebase.messaging.ktx.messaging
+import com.mate.baedalmate.BaedalMateApplication
+import com.mate.baedalmate.R
+import com.mate.baedalmate.common.extension.storeValue
+import com.mate.baedalmate.data.di.tokenDataStore
+import com.mate.baedalmate.presentation.activity.MainActivity
+import dagger.hilt.android.AndroidEntryPoint
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+@AndroidEntryPoint
+class FirebaseMessagingService : FirebaseMessagingService() {
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+    }
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        super.onMessageReceived(remoteMessage)
+        // 메시지가 data payload를 포함하고 있는 경우
+        if (remoteMessage.data.isNotEmpty()) {
+//            Log.d(TAG, "Message data payload: ${remoteMessage.data}")
+            val title = remoteMessage.data["title"]
+            val body = remoteMessage.data["body"]
+            val image = remoteMessage.data["image"]
+            val chatRoomId = remoteMessage.data["chatRoomId"]
+            val notificationType = remoteMessage.data["type"]
+
+            if (/* Check if data needs to be processed by long running job */ true) {
+                // For long-running tasks (10 seconds or more) use WorkManager.
+                // 오래 걸리는 작업인지를 판단하는 if문을 작성한 뒤, 오래 걸리는 경우엔 따로 처리
+//                scheduleJob()
+            } else {
+                // 10초 이내에 핸들링 가능한 메시지만 처리
+//                handleNow()
+            }
+
+            sendNotification(title, body, image, chatRoomId, notificationType ?: null)
+        } else if (remoteMessage.notification != null) {
+            // notification이 포함된 경우에는 foreground가 아닌이상 data로 들어온 항목들이 나중에 처리된다.
+            remoteMessage.notification?.let {
+                val body = it.body
+                sendNotification("알림 메시지", body, null, null)
+            }
+        }
+
+        // Also if you intend on generating your own notifications as a result of a received FCM
+        // message, here is where that should be initiated. See sendNotification method below.
+    }
+
+    private fun scheduleJob() {
+        // [START dispatch_job]
+        val work = OneTimeWorkRequest.Builder(MyWorker::class.java)
+            .build()
+        WorkManager.getInstance(this)
+            .beginWith(work)
+            .enqueue()
+        // [END dispatch_job]
+    }
+
+    private fun handleNow() {
+//        Log.d(TAG, "Short lived task is done.")
+    }
+
+    private fun sendNotification(
+        messageTitle: String?,
+        messageBody: String?,
+        image: String?,
+        chatRoomId: String?,
+        notificationType: String? = "default"
+    ) {
+        val id = System.currentTimeMillis().toInt()
+
+        val notificationChannel = setNotificationChannel(notificationType ?: "default")
+        val notificationManager = setNotificationManager(notificationChannel)
+        val notificationBuilder =
+            setNotificationContents(
+                id,
+                messageTitle,
+                messageBody,
+                image,
+                chatRoomId,
+                notificationChannel.id
+            )
+        notificationManager.notify(id /* ID of notification */, notificationBuilder.build())
+    }
+
+    private fun setNotificationChannel(notificationType: String): NotificationChannel {
+        val channelId = notificationType
+
+        val channelName = when (notificationType) {
+            getString(R.string.notification_channel_chat_id) -> getString(R.string.notification_channel_chat_name)
+            getString(R.string.notification_channel_recruit_id) -> getString(R.string.notification_channel_recruit_name)
+            getString(R.string.notification_channel_notice_id) -> getString(R.string.notification_channel_notice_name)
+            else -> getString(R.string.notification_channel_default_name)
+        }
+
+        val channelDescription = when (notificationType) {
+            getString(R.string.notification_channel_chat_id) -> getString(R.string.notification_channel_chat_description)
+            getString(R.string.notification_channel_recruit_id) -> getString(R.string.notification_channel_recruit_description)
+            getString(R.string.notification_channel_notice_id) -> getString(R.string.notification_channel_notice_description)
+            else -> getString(R.string.notification_channel_default_description)
+        }
+
+        return NotificationChannel(
+            channelId,
+            channelName,
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply { description = channelDescription }
+    }
+
+    private fun setNotificationManager(channel: NotificationChannel): NotificationManager {
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // Since android Oreo notification channel is needed.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationManager.createNotificationChannel(channel)
+        }
+        return notificationManager
+    }
+
+    private fun setNotificationContents(
+        messageId: Int,
+        messageTitle: String?,
+        messageBody: String?,
+        image: String?,
+        chatRoomId: String?,
+        channelId: String
+    ): NotificationCompat.Builder {
+        val notificationIntent = Intent(this, MainActivity::class.java)
+        notificationIntent.putExtra("ExtraFragment", "Notification")
+        notificationIntent.putExtra("chatRoomId", chatRoomId)
+        notificationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            messageId /* Request code */,
+            notificationIntent,
+            PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        val notificationImage = if (!image.isNullOrEmpty()) {
+            try {
+                Glide.with(BaedalMateApplication.applicationContext())
+                    .asBitmap()
+                    .load("${IMAGE_URL_PREFIX}${image}")
+                    .submit()
+                    .get()
+            } catch (exception: Exception) {
+                null
+            }
+        } else null
+
+        return NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.drawable.ic_baedalmate_logo)
+            .setContentTitle(messageTitle)
+            .setContentText(messageBody)
+            .setLargeIcon(notificationImage)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .setSound(defaultSoundUri)
+            .setContentIntent(pendingIntent)
+    }
+
+    suspend fun getCurrentToken() = suspendCoroutine<String> { continuation ->
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                Log.e(TAG, "Fetching FCM registration token failed", task.exception)
+                continuation.resume("")
+                return@OnCompleteListener
+            }
+            // Get new FCM registration token
+            val token = task.result
+            Log.d(TAG, token)
+            continuation.resume(token)
+        })
+    }
+
+    suspend fun registerFcmToken() {
+        BaedalMateApplication.applicationContext().tokenDataStore.storeValue(
+            stringPreferencesKey("fcmToken"),
+            getCurrentToken()
+        )
+        FirebaseMessaging.getInstance().isAutoInitEnabled = true
+    }
+
+    fun unregisterFcmToken() {
+        FirebaseMessaging.getInstance().isAutoInitEnabled = false
+    }
+
+    fun subscribeTopicNotice() {
+        Firebase.messaging.subscribeToTopic("notice")
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) Log.d(TAG, "NOTICE 수신")
+            }
+    }
+
+    fun unsubscribeTopicNotice() {
+        Firebase.messaging.unsubscribeFromTopic("notice")
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) Log.d(TAG, "NOTICE 수신 거부")
+            }
+    }
+
+    companion object {
+        private const val TAG = "FirebaseMessagingService"
+        private const val IMAGE_URL_PREFIX = "http://3.35.27.107:8080/images/"
+    }
+
+    internal class MyWorker(appContext: Context, workerParams: WorkerParameters) :
+        Worker(appContext, workerParams) {
+        override fun doWork(): Result {
+            // TODO(developer): add long running task here.
+            return Result.success()
+        }
+    }
+}

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/notification/NotificationApiService.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/notification/NotificationApiService.kt
@@ -1,0 +1,17 @@
+package com.mate.baedalmate.data.datasource.remote.notification
+
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
+
+interface NotificationApiService {
+    @POST("/api/v1/fcm")
+    suspend fun requestPostRegisterFcmToken(
+        @Header("Fcm-Token") fcmToken: String,
+        @Header("Device-Code") deviceCode: String,
+    ): Response<Void>
+
+    @GET("/api/v1/notification")
+    suspend fun requestGetNotifications(): Response<NotificationList>
+}

--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/notification/NotificationResponse.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/notification/NotificationResponse.kt
@@ -1,0 +1,21 @@
+package com.mate.baedalmate.data.datasource.remote.notification
+
+import com.google.gson.annotations.SerializedName
+
+data class NotificationList (
+    @SerializedName("notifications")
+    val notifications: List<Notification>
+)
+
+data class Notification (
+    @SerializedName("title")
+    val title: String,
+    @SerializedName("body")
+    val body: String,
+    @SerializedName("image")
+    val image: String,
+    @SerializedName("chatRoomId")
+    val chatRoomId: Int,
+    @SerializedName("createDate")
+    val createDate: String
+)

--- a/app/src/main/java/com/mate/baedalmate/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/di/ServiceModule.kt
@@ -2,7 +2,9 @@ package com.mate.baedalmate.data.di
 
 import com.mate.baedalmate.data.datasource.remote.block.BlockApiService
 import com.mate.baedalmate.data.datasource.remote.chat.ChatApiService
+import com.mate.baedalmate.data.datasource.remote.firebase.FirebaseMessagingService
 import com.mate.baedalmate.data.datasource.remote.member.MemberApiService
+import com.mate.baedalmate.data.datasource.remote.notification.NotificationApiService
 import com.mate.baedalmate.data.datasource.remote.recruit.RecruitApiService
 import com.mate.baedalmate.data.datasource.remote.report.ReportApiService
 import com.mate.baedalmate.data.datasource.remote.review.ReviewApiService
@@ -13,6 +15,7 @@ import com.mate.baedalmate.data.repository.BlockRepositoryImpl
 import com.mate.baedalmate.data.repository.ChatRepositoryImpl
 import com.mate.baedalmate.data.repository.KakaoLocalRepositoryImpl
 import com.mate.baedalmate.data.repository.MemberRepositoryImpl
+import com.mate.baedalmate.data.repository.NotificationRepositoryImpl
 import com.mate.baedalmate.data.repository.RecruitRepositoryImpl
 import com.mate.baedalmate.data.repository.ReportRepositoryImpl
 import com.mate.baedalmate.data.repository.ReviewRepositoryImpl
@@ -22,6 +25,7 @@ import com.mate.baedalmate.domain.repository.BlockRepository
 import com.mate.baedalmate.domain.repository.ChatRepository
 import com.mate.baedalmate.domain.repository.KakaoLocalRepository
 import com.mate.baedalmate.domain.repository.MemberRepository
+import com.mate.baedalmate.domain.repository.NotificationRepository
 import com.mate.baedalmate.domain.repository.RecruitRepository
 import com.mate.baedalmate.domain.repository.ReportRepository
 import com.mate.baedalmate.domain.repository.ReviewRepository
@@ -36,13 +40,18 @@ import com.mate.baedalmate.domain.usecase.chat.RequestGetChatRoomDetailUseCase
 import com.mate.baedalmate.domain.usecase.chat.RequestGetChatRoomListUseCase
 import com.mate.baedalmate.domain.usecase.chat.RequestGetMyMenuListUseCase
 import com.mate.baedalmate.domain.usecase.chat.RequestPutChangeMyMenuListUseCase
+import com.mate.baedalmate.domain.usecase.notification.RegisterFcmTokenUseCase
 import com.mate.baedalmate.domain.usecase.member.RequestGetHistoryPostCreatedUseCase
 import com.mate.baedalmate.domain.usecase.member.RequestGetHistoryPostParticipatedUseCase
 import com.mate.baedalmate.domain.usecase.member.RequestDeleteResignUserUseCase
+import com.mate.baedalmate.domain.usecase.notification.RequestGetFcmTokenUseCase
 import com.mate.baedalmate.domain.usecase.member.RequestGetUserInfoUseCase
 import com.mate.baedalmate.domain.usecase.member.RequestLogoutUseCase
 import com.mate.baedalmate.domain.usecase.member.RequestPutChangeMyProfileUseCase
 import com.mate.baedalmate.domain.usecase.member.RequestPutUserDormitoryUseCase
+import com.mate.baedalmate.domain.usecase.notification.RequestNotificationListUseCase
+import com.mate.baedalmate.domain.usecase.notification.SubscribeTopicNoticeUseCase
+import com.mate.baedalmate.domain.usecase.notification.UnsubscribeTopicNoticeUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestCancelParticipateRecruitPostUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestCancelRecruitPostUseCase
 import com.mate.baedalmate.domain.usecase.recruit.RequestCloseRecruitPostUseCase
@@ -70,6 +79,10 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object ServiceModule {
+
+    @Singleton
+    @Provides
+    fun provideFirebaseMessageService(): FirebaseMessagingService = FirebaseMessagingService()
 
     @Singleton
     @Provides
@@ -275,4 +288,32 @@ object ServiceModule {
     @Singleton
     @Provides
     fun provideGetBlockedUserListUseCase(blockRepository: BlockRepository): RequestGetBlockUserListUseCase = RequestGetBlockUserListUseCase(blockRepository)
+
+    @Singleton
+    @Provides
+    fun provideNotificationApiService(retrofit: Retrofit): NotificationApiService = retrofit.create(NotificationApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideNotificationRepository(notificationRepositoryImpl: NotificationRepositoryImpl, firebaseMessagingService: FirebaseMessagingService): NotificationRepository = notificationRepositoryImpl
+
+    @Singleton
+    @Provides
+    fun provideRequestNotifications(notificationRepository: NotificationRepository): RequestNotificationListUseCase = RequestNotificationListUseCase(notificationRepository)
+
+    @Singleton
+    @Provides
+    fun provideRegisterFcmTokenUseCase(notificationRepository: NotificationRepository): RegisterFcmTokenUseCase = RegisterFcmTokenUseCase(notificationRepository)
+
+    @Singleton
+    @Provides
+    fun provideGetFcmTokenUseCase(notificationRepository: NotificationRepository): RequestGetFcmTokenUseCase = RequestGetFcmTokenUseCase(notificationRepository)
+
+    @Singleton
+    @Provides
+    fun provideSubscribeTopicNoticeUseCase(notificationRepository: NotificationRepository): SubscribeTopicNoticeUseCase = SubscribeTopicNoticeUseCase(notificationRepository)
+
+    @Singleton
+    @Provides
+    fun provideUnsubscribeTopicNoticeUseCase(notificationRepository: NotificationRepository): UnsubscribeTopicNoticeUseCase = UnsubscribeTopicNoticeUseCase(notificationRepository)
 }

--- a/app/src/main/java/com/mate/baedalmate/data/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/repository/NotificationRepositoryImpl.kt
@@ -21,21 +21,20 @@ class NotificationRepositoryImpl @Inject constructor(
 
     override suspend fun registerFcmToken(fcmToken: String, deviceCode: String) {
         firebaseMessagingService.registerFcmToken()
-        notificationApiService.requestPostRegisterFcmToken(
-            fcmToken = fcmToken,
-            deviceCode = deviceCode
-        )
+        setExceptionHandling {
+            notificationApiService.requestPostRegisterFcmToken(
+                fcmToken = fcmToken,
+                deviceCode = deviceCode
+            )
+        }
     }
 
-    override suspend fun unregisterFcmToken() {
-        return firebaseMessagingService.unregisterFcmToken()
-    }
+    override suspend fun unregisterFcmToken() =
+        firebaseMessagingService.unregisterFcmToken()
 
-    override suspend fun subscribeTopicNotice() {
+    override suspend fun subscribeTopicNotice() =
         firebaseMessagingService.subscribeTopicNotice()
-    }
 
-    override suspend fun unsubscribeTopicNotice() {
+    override suspend fun unsubscribeTopicNotice() =
         firebaseMessagingService.unsubscribeTopicNotice()
-    }
 }

--- a/app/src/main/java/com/mate/baedalmate/data/repository/NotificationRepositoryImpl.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/repository/NotificationRepositoryImpl.kt
@@ -1,0 +1,41 @@
+package com.mate.baedalmate.data.repository
+
+import com.mate.baedalmate.data.datasource.remote.firebase.FirebaseMessagingService
+import com.mate.baedalmate.data.datasource.remote.notification.NotificationApiService
+import com.mate.baedalmate.data.datasource.remote.notification.NotificationList
+import com.mate.baedalmate.domain.model.ApiResult
+import com.mate.baedalmate.domain.model.setExceptionHandling
+import com.mate.baedalmate.domain.repository.NotificationRepository
+import javax.inject.Inject
+
+class NotificationRepositoryImpl @Inject constructor(
+    private val notificationApiService: NotificationApiService,
+    private val firebaseMessagingService: FirebaseMessagingService
+) : NotificationRepository {
+    override suspend fun requestNotifications(): ApiResult<NotificationList> =
+        setExceptionHandling { notificationApiService.requestGetNotifications() }
+
+    // Firebase Messaging Service
+    override suspend fun getCurrentFcmToken(): String =
+        firebaseMessagingService.getCurrentToken()
+
+    override suspend fun registerFcmToken(fcmToken: String, deviceCode: String) {
+        firebaseMessagingService.registerFcmToken()
+        notificationApiService.requestPostRegisterFcmToken(
+            fcmToken = fcmToken,
+            deviceCode = deviceCode
+        )
+    }
+
+    override suspend fun unregisterFcmToken() {
+        return firebaseMessagingService.unregisterFcmToken()
+    }
+
+    override suspend fun subscribeTopicNotice() {
+        firebaseMessagingService.subscribeTopicNotice()
+    }
+
+    override suspend fun unsubscribeTopicNotice() {
+        firebaseMessagingService.unsubscribeTopicNotice()
+    }
+}

--- a/app/src/main/java/com/mate/baedalmate/data/repository/TokenPreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/repository/TokenPreferencesRepositoryImpl.kt
@@ -77,10 +77,42 @@ class TokenPreferencesRepositoryImpl @Inject constructor(private val tokenDataSt
         }
     }
 
+    override suspend fun setFcmToken(fcmToken: String) {
+        tokenDataStorePreferences.storeValue(fcmTokenKey, fcmToken)
+    }
+
+    override suspend fun getFcmToken(): String =
+        tokenDataStorePreferences.readValue(fcmTokenKey) ?: ""
+
+    override suspend fun setNotificationPermitAll(isPermit: Boolean) =
+        tokenDataStorePreferences.storeValue(notificationPermitAllKey, isPermit)
+
+    override suspend fun getNotificationPermitAll(): Boolean =
+        tokenDataStorePreferences.readValue(notificationPermitAllKey) ?: false
+
+    override suspend fun setNotificationPermitNewMessage(isPermit: Boolean) =
+        tokenDataStorePreferences.storeValue(notificationPermitNewMessageKey, isPermit)
+
+    override suspend fun getNotificationPermitNewMessage(): Boolean  =
+        tokenDataStorePreferences.readValue(notificationPermitNewMessageKey) ?: false
+
+    override suspend fun setNotificationPermitRecruit(isPermit: Boolean) =
+        tokenDataStorePreferences.storeValue(notificationPermitRecruitKey, isPermit)
+
+    override suspend fun getNotificationPermitRecruit(): Boolean  =
+        tokenDataStorePreferences.readValue(notificationPermitRecruitKey) ?: false
+
+    override suspend fun setNotificationPermitNotice(isPermit: Boolean) =
+        tokenDataStorePreferences.storeValue(notificationPermitNoticeKey, isPermit)
+
+    override suspend fun getNotificationPermitNotice(): Boolean =
+        tokenDataStorePreferences.readValue(notificationPermitNoticeKey) ?: false
+
     private companion object {
         val kakaoAccessTokenKey = stringPreferencesKey("kakaoAccessToken")
         val accessTokenKey = stringPreferencesKey("accessToken")
         val refreshTokenKey = stringPreferencesKey("refreshToken")
+        val fcmTokenKey = stringPreferencesKey("fcmToken")
 
         val userIdKey = longPreferencesKey("userId")
         val userNicknameKey = stringPreferencesKey("userNickname")
@@ -88,5 +120,10 @@ class TokenPreferencesRepositoryImpl @Inject constructor(private val tokenDataSt
         val userDormitoryKey = stringPreferencesKey("userDormitory")
         val userScoreKey = floatPreferencesKey("userScore")
         val userAccountValidKey = booleanPreferencesKey("userAccountValid")
+
+        val notificationPermitAllKey = booleanPreferencesKey("notificationPermitAll")
+        val notificationPermitNewMessageKey = booleanPreferencesKey("notificationPermitNewMessage")
+        val notificationPermitRecruitKey = booleanPreferencesKey("notificationPermitRecruit")
+        val notificationPermitNoticeKey = booleanPreferencesKey("notificationPermitNotice")
     }
 }

--- a/app/src/main/java/com/mate/baedalmate/domain/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/repository/NotificationRepository.kt
@@ -1,0 +1,15 @@
+package com.mate.baedalmate.domain.repository
+
+import com.mate.baedalmate.data.datasource.remote.notification.NotificationList
+import com.mate.baedalmate.domain.model.ApiResult
+
+interface NotificationRepository {
+    suspend fun requestNotifications(): ApiResult<NotificationList>
+
+    // Firebase Messaging Service
+    suspend fun getCurrentFcmToken(): String
+    suspend fun registerFcmToken(fcmToken: String, deviceCode: String)
+    suspend fun unregisterFcmToken()
+    suspend fun subscribeTopicNotice()
+    suspend fun unsubscribeTopicNotice()
+}

--- a/app/src/main/java/com/mate/baedalmate/domain/repository/TokenPreferencesRepository.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/repository/TokenPreferencesRepository.kt
@@ -14,5 +14,15 @@ interface TokenPreferencesRepository {
     suspend fun getUserInfo(): UserInfoResponse
     suspend fun setUserAccountIsValid(isValid: Boolean)
     suspend fun getUserAccountIsValid(): Boolean
+    suspend fun setFcmToken(fcmToken: String)
+    suspend fun getFcmToken(): String
+    suspend fun setNotificationPermitAll(isPermit: Boolean)
+    suspend fun getNotificationPermitAll(): Boolean
+    suspend fun setNotificationPermitNewMessage(isPermit: Boolean)
+    suspend fun getNotificationPermitNewMessage(): Boolean
+    suspend fun setNotificationPermitRecruit(isPermit: Boolean)
+    suspend fun getNotificationPermitRecruit(): Boolean
+    suspend fun setNotificationPermitNotice(isPermit: Boolean)
+    suspend fun getNotificationPermitNotice(): Boolean
     suspend fun clearAllInfo()
 }

--- a/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/RegisterFcmTokenUseCase.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/RegisterFcmTokenUseCase.kt
@@ -1,0 +1,10 @@
+package com.mate.baedalmate.domain.usecase.notification
+
+import com.mate.baedalmate.domain.repository.NotificationRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RegisterFcmTokenUseCase @Inject constructor(private val notificationRepository: NotificationRepository) {
+    suspend operator fun invoke(fcmToken: String, deviceCode: String) = notificationRepository.registerFcmToken(fcmToken = fcmToken, deviceCode = deviceCode)
+}

--- a/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/RequestGetFcmTokenUseCase.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/RequestGetFcmTokenUseCase.kt
@@ -1,0 +1,10 @@
+package com.mate.baedalmate.domain.usecase.notification
+
+import com.mate.baedalmate.domain.repository.NotificationRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RequestGetFcmTokenUseCase @Inject constructor(private val notificationRepository: NotificationRepository) {
+    suspend operator fun invoke() = notificationRepository.getCurrentFcmToken()
+}

--- a/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/RequestNotificationListUseCase.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/RequestNotificationListUseCase.kt
@@ -1,0 +1,10 @@
+package com.mate.baedalmate.domain.usecase.notification
+
+import com.mate.baedalmate.domain.repository.NotificationRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RequestNotificationListUseCase @Inject constructor(private val notificationRepository: NotificationRepository) {
+    suspend operator fun invoke() = notificationRepository.requestNotifications()
+}

--- a/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/SubscribeTopicNoticeUseCase.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/SubscribeTopicNoticeUseCase.kt
@@ -1,0 +1,10 @@
+package com.mate.baedalmate.domain.usecase.notification
+
+import com.mate.baedalmate.domain.repository.NotificationRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SubscribeTopicNoticeUseCase @Inject constructor(private val notificationRepository: NotificationRepository) {
+    suspend operator fun invoke() = notificationRepository.subscribeTopicNotice()
+}

--- a/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/UnregisterFcmTokenUseCase.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/UnregisterFcmTokenUseCase.kt
@@ -1,0 +1,10 @@
+package com.mate.baedalmate.domain.usecase.notification
+
+import com.mate.baedalmate.domain.repository.NotificationRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UnregisterFcmTokenUseCase @Inject constructor(private val notificationRepository: NotificationRepository) {
+    suspend operator fun invoke() = notificationRepository.unregisterFcmToken()
+}

--- a/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/UnsubscribeTopicNoticeUseCase.kt
+++ b/app/src/main/java/com/mate/baedalmate/domain/usecase/notification/UnsubscribeTopicNoticeUseCase.kt
@@ -1,0 +1,10 @@
+package com.mate.baedalmate.domain.usecase.notification
+
+import com.mate.baedalmate.domain.repository.NotificationRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UnsubscribeTopicNoticeUseCase @Inject constructor(private val notificationRepository: NotificationRepository) {
+    suspend operator fun invoke() = notificationRepository.unsubscribeTopicNotice()
+}

--- a/app/src/main/java/com/mate/baedalmate/presentation/activity/MainActivity.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/activity/MainActivity.kt
@@ -1,10 +1,19 @@
 package com.mate.baedalmate.presentation.activity
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.provider.Settings
 import android.view.View
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
@@ -13,22 +22,108 @@ import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.ktx.Firebase
 import com.mate.baedalmate.R
 import com.mate.baedalmate.databinding.ActivityMainBinding
+import com.mate.baedalmate.presentation.fragment.home.HomeFragmentDirections
 import com.mate.baedalmate.presentation.viewmodel.MemberViewModel
+import com.mate.baedalmate.presentation.viewmodel.NotificationViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private lateinit var firebaseAnalytics: FirebaseAnalytics
     private lateinit var binding: ActivityMainBinding
     private val memberViewModel by viewModels<MemberViewModel>()
+    private val notificationViewModel by viewModels<NotificationViewModel>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         firebaseAnalytics = Firebase.analytics
+        setFcm()
+        getNotificationData()
         initBottomNavigation()
         setBottomNaviVisibility()
         observeAccountValid()
+        askNotificationPermission()
+    }
+
+    private val permissionLauncherNotification =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            val deniedList: List<String> = permissions.filter {
+                !it.value
+            }.map {
+                it.key
+            }
+
+            when {
+                deniedList.isNotEmpty() -> {
+                    val map = deniedList.groupBy { permission ->
+                        if (shouldShowRequestPermissionRationale(permission)) "DENIED" else "EXPLAINED"
+                    }
+                    map["DENIED"]?.let {
+                        // request denied , request again
+                        Toast.makeText(this,
+                            "알림 권한을 허용하지 않으면 정상적 사용이 불가능할 수 있습니다",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        ActivityCompat.requestPermissions(
+                            this,
+                            notificationPermission,
+                            1000
+                        )
+                    }
+                    map["EXPLAINED"]?.let {
+                        Intent().apply {
+                            action = Settings.ACTION_APP_NOTIFICATION_SETTINGS
+                            putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+                        }
+                        Toast.makeText(
+                            this,
+                            "설정에서 알림을 허용으로 변경해주세요",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+                else -> {
+                    //All request are permitted
+                    // 알림 최초 허용시에 모든 알림 허용처리
+                    with(notificationViewModel) {
+                        setNotificationAll(true)
+                        setNotificationNewMessage(true)
+                        setNotificationRecruit(true)
+                        setNotificationNotice(true)
+                    }
+                }
+            }
+        }
+
+    private fun askNotificationPermission() {
+        // This is only necessary for API level >= 33 (TIRAMISU)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+                // FCM SDK (and your app) can post notifications.
+            } else if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                // TODO: display an educational UI explaining to the user the features that will be enabled
+                // by them granting the POST_NOTIFICATION permission. This UI should provide the user
+                // "OK" and "No thanks" buttons. If the user selects "OK," directly request the permission.
+                // If the user selects "No thanks," allow the user to continue without notifications.
+            } else {
+                // Directly ask for the permission
+                permissionLauncherNotification.launch(notificationPermission)
+            }
+        }
+    }
+
+    private fun getNotificationData() {
+        val extraFragment = intent.getStringExtra(IS_NAVIGATE_FRAGMENT_EXIST_FLAG)
+        if (extraFragment != null && extraFragment == NAVIGATE_FRAGMENT_FLAG_NAVIGATION) {
+            val chatRoomId = intent.getStringExtra("chatRoomId")?.toInt()
+            if (chatRoomId != null) findNavController().navigate(
+                HomeFragmentDirections.actionHomeFragmentToChatFragment(
+                    roomId = chatRoomId
+                )
+            ) else findNavController().navigate(HomeFragmentDirections.actionHomeFragmentToNotificationFragment())
+        }
     }
 
     private fun initBottomNavigation() {
@@ -67,5 +162,17 @@ class MainActivity : AppCompatActivity() {
             } else {
             }
         }
+    }
+
+    private fun setFcm() {
+        lifecycleScope.launch {
+            notificationViewModel.registerFcmToken(contentResolver = this@MainActivity.contentResolver)
+        }
+    }
+
+    companion object {
+        const val IS_NAVIGATE_FRAGMENT_EXIST_FLAG = "ExtraFragment"
+        const val NAVIGATE_FRAGMENT_FLAG_NAVIGATION = "Notification"
+        val notificationPermission = arrayOf(Manifest.permission.POST_NOTIFICATIONS)
     }
 }

--- a/app/src/main/java/com/mate/baedalmate/presentation/adapter/notification/NotificationAdapter.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/adapter/notification/NotificationAdapter.kt
@@ -5,30 +5,34 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Priority
 import com.bumptech.glide.RequestManager
+import com.mate.baedalmate.common.TimeChangerUtil
+import com.mate.baedalmate.data.datasource.remote.notification.Notification
 import com.mate.baedalmate.databinding.ItemNotificationBinding
-import com.mate.baedalmate.domain.model.RecruitDto
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
-class NotificationAdapter (private val requestManager: RequestManager) :
-    ListAdapter<RecruitDto, NotificationAdapter.NotificationViewHolder>(diffCallback) {
+class NotificationAdapter(private val requestManager: RequestManager) :
+    ListAdapter<Notification, NotificationAdapter.NotificationViewHolder>(diffCallback) {
     companion object {
-        private val diffCallback = object : DiffUtil.ItemCallback<RecruitDto>() {
+        private val diffCallback = object : DiffUtil.ItemCallback<Notification>() {
             override fun areItemsTheSame(
-                oldItem: RecruitDto,
-                newItem: RecruitDto,
+                oldItem: Notification,
+                newItem: Notification,
             ) =
-                oldItem.recruitId == newItem.recruitId
+                oldItem == newItem
 
             override fun areContentsTheSame(
-                oldItem: RecruitDto,
-                newItem: RecruitDto,
+                oldItem: Notification,
+                newItem: Notification,
             ): Boolean =
                 oldItem == newItem
         }
     }
 
     interface OnItemClickListener {
-        fun notificationClick(postId: Int, pos: Int)
+        fun notificationClick(roomId: Int, pos: Int)
     }
 
     private var listener: OnItemClickListener? = null
@@ -55,29 +59,37 @@ class NotificationAdapter (private val requestManager: RequestManager) :
         holder.bind(getItem(position))
     }
 
-    override fun submitList(list: MutableList<RecruitDto>?) {
+    override fun submitList(list: MutableList<Notification>?) {
         super.submitList(list?.let { ArrayList(it) })
     }
 
     inner class NotificationViewHolder(private val binding: ItemNotificationBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(item: RecruitDto) {
-            // TODO 수정
+        fun bind(item: Notification) {
+            val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+            val createTime = LocalDateTime.parse(item.createDate, formatter)
             val pos = adapterPosition
-            if (pos != RecyclerView.NO_POSITION) {
-                binding.layoutNotificationItem.setOnClickListener {
-                    listener?.notificationClick(item.recruitId, pos)
-                }
-            }
 
-//            requestManager.load("http://3.35.27.107:8080/images/${item.image}")
-//                .thumbnail(0.1f)
-//                .priority(Priority.HIGH)
-//                .centerCrop()
-//                .into(binding.imgNotificationThumbnail)
-//            binding.tvNotificationTitle.text =
-//            binding.tvNotificationDescription.text =
-//            binding.tvNotificationTime.text =
+            with(binding) {
+                if (pos != RecyclerView.NO_POSITION) {
+                    layoutNotificationItem.setOnClickListener {
+                        listener?.notificationClick(item.chatRoomId, pos)
+                    }
+                }
+
+                requestManager.load("http://3.35.27.107:8080/images/${item.image}")
+                    .thumbnail(0.1f)
+                    .priority(Priority.HIGH)
+                    .centerCrop()
+                    .into(imgNotificationThumbnail)
+                tvNotificationTitle.text = item.title
+                tvNotificationDescription.text = item.body
+                tvNotificationTime.text = TimeChangerUtil.getTimePassed(
+                    tvNotificationTime.context,
+                    createTime,
+                    LocalDateTime.now()
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/mypage/MyPageFragment.kt
@@ -68,11 +68,6 @@ class MyPageFragment : Fragment() {
         setAccountActionClickListener()
     }
 
-    override fun onResume() {
-        super.onResume()
-        initNotification()
-    }
-
     override fun onDestroyView() {
         super.onDestroyView()
         ConfirmAlertDialog.hideConfirmDialog(logoutAlertDialog)
@@ -114,17 +109,19 @@ class MyPageFragment : Fragment() {
     }
 
     private fun setMenusSettingClickListener() {
-        // TODO 알림 설정
-        binding.layoutMyPageMenusSettingMyProfileChange.setOnDebounceClickListener {
-            findNavController().navigate(R.id.action_myPageFragment_to_myProfileChangeFragment)
-        }
-
-        binding.layoutMyPageMenusSettingLocationChange.setOnDebounceClickListener {
-            findNavController().navigate(R.id.action_myPageFragment_to_locationCertificationFragment)
-        }
-
-        binding.layoutMyPageMenusSettingBlock.setOnDebounceClickListener {
-            findNavController().navigate(R.id.action_myPageFragment_to_blockUserListFragment)
+        with(binding) {
+            layoutMyPageMenusSettingNotification.setOnDebounceClickListener {
+                findNavController().navigate(R.id.action_myPageFragment_to_myPageSetNotificationFragment)
+            }
+            layoutMyPageMenusSettingMyProfileChange.setOnDebounceClickListener {
+                findNavController().navigate(R.id.action_myPageFragment_to_myProfileChangeFragment)
+            }
+            layoutMyPageMenusSettingLocationChange.setOnDebounceClickListener {
+                findNavController().navigate(R.id.action_myPageFragment_to_locationCertificationFragment)
+            }
+            layoutMyPageMenusSettingBlock.setOnDebounceClickListener {
+                findNavController().navigate(R.id.action_myPageFragment_to_blockUserListFragment)
+            }
         }
     }
 
@@ -228,40 +225,6 @@ class MyPageFragment : Fragment() {
             } else if (isSuccess.getContentIfNotHandled() == false) {
                 Toast.makeText(requireContext(), getString(R.string.resign_fail_toast_message), Toast.LENGTH_SHORT).show()
             }
-        }
-    }
-
-    private fun initNotification() {
-        val currentNotificationState =
-            NotificationManagerCompat.from(requireContext()).areNotificationsEnabled()
-        val intent = when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> {
-                Intent().apply {
-                    action = Settings.ACTION_APP_NOTIFICATION_SETTINGS
-                    putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().packageName)
-                }
-            }
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP -> {
-                Intent().apply {
-                    action = "android.settings.APP_NOTIFICATION_SETTINGS"
-                    putExtra("app_package", requireContext().packageName)
-                    putExtra("app_uid", requireContext().applicationInfo?.uid)
-                }
-            }
-            else -> {
-                Intent().apply {
-                    action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-                    addCategory(Intent.CATEGORY_DEFAULT)
-                    data = Uri.parse("package:${requireContext().packageName}")
-                }
-            }
-        }
-
-        binding.btnToggleMyPageMenusSettingNotification.isChecked = currentNotificationState
-        binding.btnToggleMyPageMenusSettingNotification.setOnTouchListener { _, _ ->
-            binding.btnToggleMyPageMenusSettingNotification.isClickable = false
-            startActivity(intent)
-            false
         }
     }
 

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/mypage/MyPageSettingNotificationFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/mypage/MyPageSettingNotificationFragment.kt
@@ -1,0 +1,144 @@
+package com.mate.baedalmate.presentation.fragment.mypage
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.Settings
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.app.NotificationManagerCompat
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
+import com.mate.baedalmate.R
+import com.mate.baedalmate.common.autoCleared
+import com.mate.baedalmate.common.extension.setOnDebounceClickListener
+import com.mate.baedalmate.databinding.FragmentMyPageSettingNotificationBinding
+import com.mate.baedalmate.presentation.viewmodel.NotificationViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MyPageSettingNotificationFragment : Fragment() {
+    private var binding by autoCleared<FragmentMyPageSettingNotificationBinding>()
+    private val notificationViewModel by activityViewModels<NotificationViewModel>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentMyPageSettingNotificationBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setBackClickListener()
+        initNotificationStates()
+        setNotificationAll()
+        setNotificationNewMessage()
+        setNotificationRecruit()
+        setNotificationNotice()
+    }
+
+    private fun setBackClickListener() {
+        binding.btnMyPageSettingNotificationActionbarBack.setOnDebounceClickListener {
+            findNavController().navigateUp()
+        }
+    }
+
+    private fun initNotificationStates() {
+        // 전체 알림 먼저 확인한뒤 하위 알림들 확인
+        if (notificationViewModel.getNotificationSettings(getString(R.string.notification_type_all))) {
+            with(binding) {
+                btnToggleMyPageMenusSettingNotificationAll.isChecked =
+                    notificationViewModel.getNotificationSettings(getString(R.string.notification_type_all))
+                btnToggleMyPageMenusSettingNotificationNewMessage.isChecked =
+                    notificationViewModel.getNotificationSettings(getString(R.string.notification_type_newMessage))
+                btnToggleMyPageMenusSettingNotificationRecruit.isChecked =
+                    notificationViewModel.getNotificationSettings(getString(R.string.notification_type_recruit))
+                btnToggleMyPageMenusSettingNotificationNotice.isChecked =
+                    notificationViewModel.getNotificationSettings(getString(R.string.notification_type_notice))
+            }
+        } else {
+            showNotificationStates(isOnState = false)
+        }
+    }
+
+    private fun setNotificationAll() {
+        binding.btnToggleMyPageMenusSettingNotificationAll.setOnCheckedChangeListener { _, isChecked ->
+            // 모든 알림 설정이 ON/OFF 될때 하위 알림들도 모두 따라가도록 설정
+            showNotificationStates(isOnState = isChecked)
+            notificationViewModel.setNotificationAll(isChecked)
+            if (isChecked) notificationViewModel.registerFcmToken(requireContext().contentResolver)
+            else notificationViewModel.unregisterFcmToken()
+        }
+    }
+
+    private fun showNotificationStates(isOnState: Boolean) {
+        with(binding) {
+            btnToggleMyPageMenusSettingNotificationNewMessage.isEnabled = isOnState
+            btnToggleMyPageMenusSettingNotificationRecruit.isEnabled = isOnState
+            btnToggleMyPageMenusSettingNotificationNotice.isEnabled = isOnState
+        }
+        with(binding) {
+            btnToggleMyPageMenusSettingNotificationNewMessage.isChecked = isOnState
+            btnToggleMyPageMenusSettingNotificationRecruit.isChecked = isOnState
+            btnToggleMyPageMenusSettingNotificationNotice.isChecked = isOnState
+        }
+    }
+
+    private fun setNotificationNewMessage() {
+        binding.btnToggleMyPageMenusSettingNotificationNewMessage.setOnCheckedChangeListener { _, isChecked ->
+            notificationViewModel.setNotificationNewMessage(isChecked)
+        }
+    }
+
+    private fun setNotificationRecruit() {
+        binding.btnToggleMyPageMenusSettingNotificationRecruit.setOnCheckedChangeListener { _, isChecked ->
+            notificationViewModel.setNotificationRecruit(isChecked)
+        }
+    }
+
+    private fun setNotificationNotice() {
+        binding.btnToggleMyPageMenusSettingNotificationNotice.setOnCheckedChangeListener { _, isChecked ->
+            notificationViewModel.setNotificationNotice(isChecked)
+        }
+    }
+
+    // 설정으로 이동해 알림을 끄는 방법
+    private fun initNotification() {
+        val currentNotificationState =
+            NotificationManagerCompat.from(requireContext()).areNotificationsEnabled()
+        val intent = when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> {
+                Intent().apply {
+                    action = Settings.ACTION_APP_NOTIFICATION_SETTINGS
+                    putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().packageName)
+                }
+            }
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP -> {
+                Intent().apply {
+                    action = "android.settings.APP_NOTIFICATION_SETTINGS"
+                    putExtra("app_package", requireContext().packageName)
+                    putExtra("app_uid", requireContext().applicationInfo?.uid)
+                }
+            }
+            else -> {
+                Intent().apply {
+                    action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                    addCategory(Intent.CATEGORY_DEFAULT)
+                    data = Uri.parse("package:${requireContext().packageName}")
+                }
+            }
+        }
+
+        binding.btnToggleMyPageMenusSettingNotificationAll.isChecked = currentNotificationState
+        binding.btnToggleMyPageMenusSettingNotificationAll.setOnTouchListener { _, _ ->
+            binding.btnToggleMyPageMenusSettingNotificationAll.isClickable = false
+            startActivity(intent)
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/notification/NotificationFragment.kt
@@ -5,17 +5,26 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.mate.baedalmate.common.autoCleared
+import com.mate.baedalmate.common.extension.setOnDebounceClickListener
 import com.mate.baedalmate.databinding.FragmentNotificationBinding
 import com.mate.baedalmate.presentation.adapter.notification.NotificationAdapter
+import com.mate.baedalmate.presentation.viewmodel.NotificationViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class NotificationFragment : Fragment() {
     private var binding by autoCleared<FragmentNotificationBinding>()
+    private val notificationViewModel by activityViewModels<NotificationViewModel>()
     private lateinit var notificationAdapter: NotificationAdapter
     private lateinit var glideRequestManager: RequestManager
 
@@ -34,19 +43,68 @@ class NotificationFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setBackClickListener()
         getNotification()
         initListAdapter()
     }
 
+    private fun setBackClickListener() {
+        binding.btnNotificationActionbarBack.setOnDebounceClickListener {
+            findNavController().navigateUp()
+        }
+    }
+
     private fun getNotification() {
-        // TODO
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                showLoadingView()
+                notificationViewModel.getNotifications()
+            }
+        }
+    }
+
+    private fun observeNotifications() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                notificationViewModel.notifications.observe(viewLifecycleOwner) { notifications ->
+                    hideLoadingView()
+                    notificationAdapter.submitList(notifications.notifications.toMutableList())
+                }
+            }
+        }
     }
 
     private fun initListAdapter() {
         notificationAdapter = NotificationAdapter(requestManager = glideRequestManager)
-        binding.rvNotificationResultList.layoutManager = LinearLayoutManager(requireContext())
+        with(binding.rvNotificationResultList) {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = notificationAdapter
+        }
+        setListAdapterItemClickListener()
+        observeNotifications()
+    }
+
+    private fun setListAdapterItemClickListener() {
+        notificationAdapter.setOnItemClickListener(object : NotificationAdapter.OnItemClickListener {
+            override fun notificationClick(roomId: Int, pos: Int) {
+                findNavController().navigate(NotificationFragmentDirections.actionNotificationFragmentToChatFragment(
+                    roomId = roomId
+                ))
+            }
+        })
+    }
+
+    private fun showLoadingView() {
         with(binding) {
-            rvNotificationResultList.adapter = notificationAdapter
+            rvNotificationResultList.visibility = View.INVISIBLE
+            lottieNotificationLoading.visibility = View.VISIBLE
+        }
+    }
+
+    private fun hideLoadingView() {
+        with(binding) {
+            rvNotificationResultList.visibility = View.VISIBLE
+            lottieNotificationLoading.visibility = View.GONE
         }
     }
 }

--- a/app/src/main/java/com/mate/baedalmate/presentation/viewmodel/NotificationViewModel.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/viewmodel/NotificationViewModel.kt
@@ -1,0 +1,97 @@
+package com.mate.baedalmate.presentation.viewmodel
+
+import android.content.ContentResolver
+import android.provider.Settings
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mate.baedalmate.data.datasource.remote.notification.NotificationList
+import com.mate.baedalmate.domain.model.ApiResult
+import com.mate.baedalmate.domain.repository.TokenPreferencesRepository
+import com.mate.baedalmate.domain.usecase.notification.RegisterFcmTokenUseCase
+import com.mate.baedalmate.domain.usecase.notification.RequestGetFcmTokenUseCase
+import com.mate.baedalmate.domain.usecase.notification.RequestNotificationListUseCase
+import com.mate.baedalmate.domain.usecase.notification.SubscribeTopicNoticeUseCase
+import com.mate.baedalmate.domain.usecase.notification.UnregisterFcmTokenUseCase
+import com.mate.baedalmate.domain.usecase.notification.UnsubscribeTopicNoticeUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NotificationViewModel @Inject constructor(
+    private val registerFcmTokenUseCase: RegisterFcmTokenUseCase,
+    private val unregisterFcmTokenUseCase: UnregisterFcmTokenUseCase,
+    private val requestGetFcmTokenUseCase: RequestGetFcmTokenUseCase,
+    private val subscribeTopicNoticeUseCase: SubscribeTopicNoticeUseCase,
+    private val unsubscribeTopicNoticeUseCase: UnsubscribeTopicNoticeUseCase,
+    private val requestNotificationListUseCase: RequestNotificationListUseCase,
+    private val tokenPreferencesRepository: TokenPreferencesRepository
+) : ViewModel() {
+    private val _notifications = MutableLiveData<NotificationList>()
+    val notifications: LiveData<NotificationList> get() = _notifications
+
+    fun registerFcmToken(contentResolver: ContentResolver) = viewModelScope.launch {
+        registerFcmTokenUseCase(
+            fcmToken = requestGetFcmTokenUseCase(),
+            deviceCode = Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID)
+        )
+    }
+
+    fun unregisterFcmToken() = viewModelScope.launch {
+        unregisterFcmTokenUseCase()
+    }
+
+    fun setNotificationAll(isPermit: Boolean) = viewModelScope.launch {
+        tokenPreferencesRepository.setNotificationPermitAll(isPermit)
+    }
+
+    fun setNotificationNewMessage(isPermit: Boolean) = viewModelScope.launch {
+        // TODO 서버에 새로운 메시지 관련 알림 수신/미수신 요청
+        tokenPreferencesRepository.setNotificationPermitNewMessage(isPermit)
+    }
+
+    fun setNotificationRecruit(isPermit: Boolean) = viewModelScope.launch {
+        // TODO 서버에 모집글 알림 수신/미수신 요청
+        tokenPreferencesRepository.setNotificationPermitRecruit(isPermit)
+    }
+
+    fun setNotificationNotice(isPermit: Boolean) = viewModelScope.launch {
+        // 서버에서 받아오지 않도록 구독 취소
+        if (isPermit) subscribeTopicNoticeUseCase()
+        else unsubscribeTopicNoticeUseCase()
+
+        // 내부 저장소에 설정값 저장
+        tokenPreferencesRepository.setNotificationPermitNotice(isPermit)
+    }
+
+    fun getNotificationSettings(notificationType: String): Boolean {
+        var isPermit = false
+        viewModelScope.launch {
+            isPermit = when (notificationType) {
+                "all" -> tokenPreferencesRepository.getNotificationPermitAll()
+                "newMessage" -> tokenPreferencesRepository.getNotificationPermitNewMessage()
+                "recruit" -> tokenPreferencesRepository.getNotificationPermitRecruit()
+                "notice" -> tokenPreferencesRepository.getNotificationPermitNotice()
+                else -> false
+            }
+        }
+        return isPermit
+    }
+
+    fun getNotifications() = viewModelScope.launch {
+        requestNotificationListUseCase()?.let { ApiResponse ->
+            when (ApiResponse.status) {
+                ApiResult.Status.SUCCESS -> {
+                    ApiResponse.data?.let { notificationsResponse ->
+                        _notifications.postValue(notificationsResponse)
+                    }
+                }
+                else -> {
+
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -74,7 +74,6 @@
                             android:background="@android:color/transparent"
                             android:paddingHorizontal="15dp"
                             android:src="@drawable/ic_notification"
-                            android:visibility="gone"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintHorizontal_bias="1.0"

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -269,15 +269,11 @@
                             android:text="@string/setting_notification"
                             android:textColor="@color/gray_dark_666666" />
 
-                        <androidx.appcompat.widget.SwitchCompat
-                            android:id="@+id/btn_toggle_my_page_menus_setting_notification"
+                        <ImageView
                             android:layout_width="wrap_content"
-                            android:layout_height="0dp"
+                            android:layout_height="wrap_content"
                             android:layout_gravity="center"
-                            android:padding="0dp"
-                            android:thumb="@drawable/selector_thumb_toggle_button"
-                            app:track="@drawable/selector_background_toggle_button"
-                            tools:checked="true" />
+                            android:src="@drawable/ic_arrow_right" />
                     </LinearLayout>
 
                     <View

--- a/app/src/main/res/layout/fragment_my_page_setting_notification.xml
+++ b/app/src/main/res/layout/fragment_my_page_setting_notification.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".presentation.fragment.mypage.MyPageSettingNotificationFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_my_page_setting_notification_actionbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0">
+
+            <ImageButton
+                android:id="@+id/btn_my_page_setting_notification_actionbar_back"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@android:color/transparent"
+                android:paddingHorizontal="16dp"
+                android:src="@drawable/ic_left_arrow"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_my_page_setting_notification_actionbar_title"
+                style="@style/style_title1_kor"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/my_page_setting_notification_title_actionbar"
+                android:textColor="@color/black_000000"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="0.5" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <LinearLayout
+            android:id="@+id/layout_my_page_setting_notification_contents"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:orientation="vertical"
+            android:paddingHorizontal="18dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_my_page_setting_notification_actionbar">
+
+            <LinearLayout
+                android:id="@+id/layout_my_page_menus_setting_notification_all"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="14dp"
+                android:paddingBottom="10dp">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        style="@style/style_semi_title_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/my_page_setting_notification_title_all"
+                        android:textColor="@color/gray_dark_666666" />
+
+                    <TextView
+                        style="@style/style_caption1_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/my_page_setting_notification_description_all"
+                        android:textColor="@color/gray_main_C4C4C4" />
+                </LinearLayout>
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/btn_toggle_my_page_menus_setting_notification_all"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_gravity="center"
+                    android:padding="0dp"
+                    android:thumb="@drawable/selector_thumb_toggle_button"
+                    app:track="@drawable/selector_background_toggle_button"
+                    tools:checked="true" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/layout_my_page_menus_setting_notification_new_message"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="14dp"
+                android:paddingBottom="10dp">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        style="@style/style_semi_title_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/my_page_setting_notification_title_new_message"
+                        android:textColor="@color/gray_dark_666666" />
+
+                    <TextView
+                        style="@style/style_caption1_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/my_page_setting_notification_description_new_message"
+                        android:textColor="@color/gray_main_C4C4C4" />
+                </LinearLayout>
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/btn_toggle_my_page_menus_setting_notification_new_message"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_gravity="center"
+                    android:padding="0dp"
+                    android:thumb="@drawable/selector_thumb_toggle_button"
+                    app:track="@drawable/selector_background_toggle_button"
+                    tools:checked="true" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/layout_my_page_menus_setting_notification_recruit"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="14dp"
+                android:paddingBottom="10dp">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        style="@style/style_semi_title_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/my_page_setting_notification_title_recruit"
+                        android:textColor="@color/gray_dark_666666" />
+
+                    <TextView
+                        style="@style/style_caption1_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/my_page_setting_notification_description_recruit"
+                        android:textColor="@color/gray_main_C4C4C4" />
+                </LinearLayout>
+
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/btn_toggle_my_page_menus_setting_notification_recruit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_gravity="center"
+                    android:padding="0dp"
+                    android:thumb="@drawable/selector_thumb_toggle_button"
+                    app:track="@drawable/selector_background_toggle_button"
+                    tools:checked="true" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/layout_my_page_menus_setting_notification_notice"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="14dp"
+                android:paddingBottom="10dp">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        style="@style/style_semi_title_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/my_page_setting_notification_title_notice"
+                        android:textColor="@color/gray_dark_666666" />
+
+                    <TextView
+                        style="@style/style_caption1_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/my_page_setting_notification_description_notice"
+                        android:textColor="@color/gray_main_C4C4C4" />
+                </LinearLayout>
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/btn_toggle_my_page_menus_setting_notification_notice"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_gravity="center"
+                    android:padding="0dp"
+                    android:thumb="@drawable/selector_thumb_toggle_button"
+                    app:track="@drawable/selector_background_toggle_button"
+                    tools:checked="true" />
+            </LinearLayout>
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_notification.xml
+++ b/app/src/main/res/layout/fragment_notification.xml
@@ -52,6 +52,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:orientation="vertical"
+            android:visibility="invisible"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -61,5 +62,19 @@
             app:layout_constraintVertical_bias="0.0"
             tools:itemCount="10"
             tools:listitem="@layout/item_notification" />
+
+        <com.airbnb.lottie.LottieAnimationView
+            android:id="@+id/lottie_notification_loading"
+            android:layout_width="match_parent"
+            android:layout_height="80dp"
+            android:paddingVertical="10dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_notification_actionbar"
+            app:lottie_autoPlay="true"
+            app:lottie_loop="true"
+            app:lottie_rawRes="@raw/lottie_loading_post_list"
+            app:lottie_speed="1" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -45,6 +45,13 @@
             app:exitAnim="@anim/slide_to_left"
             app:popEnterAnim="@anim/slide_from_left"
             app:popExitAnim="@anim/slide_to_right" />
+        <action
+            android:id="@+id/action_homeFragment_to_chatFragment"
+            app:destination="@id/ChatFragment"
+            app:enterAnim="@anim/slide_from_right"
+            app:exitAnim="@anim/slide_to_left"
+            app:popEnterAnim="@anim/slide_from_left"
+            app:popExitAnim="@anim/slide_to_right" />
     </fragment>
 
     <fragment
@@ -73,7 +80,16 @@
         android:id="@+id/NotificationFragment"
         android:name="com.mate.baedalmate.presentation.fragment.notification.NotificationFragment"
         android:label="fragment_notification"
-        tools:layout="@layout/fragment_notification" />
+        tools:layout="@layout/fragment_notification">
+
+        <action
+            android:id="@+id/action_notificationFragment_to_chatFragment"
+            app:destination="@id/ChatFragment"
+            app:enterAnim="@anim/slide_from_right"
+            app:exitAnim="@anim/slide_to_left"
+            app:popEnterAnim="@anim/slide_from_left"
+            app:popExitAnim="@anim/slide_to_right" />
+    </fragment>
 
     <fragment
         android:id="@+id/PostCategoryListFragment"
@@ -471,6 +487,13 @@
             app:popEnterAnim="@anim/slide_from_left"
             app:popExitAnim="@anim/slide_to_right" />
         <action
+            android:id="@+id/action_myPageFragment_to_myPageSetNotificationFragment"
+            app:destination="@id/MyPageSettingNotificationFragment"
+            app:enterAnim="@anim/slide_from_right"
+            app:exitAnim="@anim/slide_to_left"
+            app:popEnterAnim="@anim/slide_from_left"
+            app:popExitAnim="@anim/slide_to_right" />
+        <action
             android:id="@+id/action_myPageFragment_to_myProfileChangeFragment"
             app:destination="@id/MyProfileChangeFragment"
             app:enterAnim="@anim/slide_from_right"
@@ -520,6 +543,12 @@
             app:popEnterAnim="@anim/slide_from_left"
             app:popExitAnim="@anim/slide_to_right" />
     </fragment>
+
+    <fragment
+        android:id="@+id/MyPageSettingNotificationFragment"
+        android:name="com.mate.baedalmate.presentation.fragment.mypage.MyPageSettingNotificationFragment"
+        android:label="fragment_my_profile_change"
+        tools:layout="@layout/fragment_my_page_setting_notification"/>
 
     <fragment
         android:id="@+id/MyProfileChangeFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,36 @@
     <string name="participate_complete">모집 완료</string>
     <string name="participate_close">모집 마감</string>
 
+    <!-- Notification -->
+    <string name="notification_type_all">all</string>
+    <string name="notification_type_newMessage">newMessage</string>
+    <string name="notification_type_recruit">recruit</string>
+    <string name="notification_type_notice">notice</string>
+    <string name="notification_channel_default_id" translatable="false">notification</string>
+    <string name="notification_channel_default_name" translatable="false">기본 알림</string>
+    <string name="notification_channel_default_description" translatable="false">기타 알림을 설정합니다</string>
+    <string name="notification_channel_notice_id" translatable="false">notice</string>
+    <string name="notification_channel_notice_name" translatable="false">공지 알림</string>
+    <string name="notification_channel_notice_description" translatable="false">새로운 공지사항이 등록되면 알림을 받습니다</string>
+    <string name="notification_channel_chat_id" translatable="false">chat</string>
+    <string name="notification_channel_chat_name" translatable="false">새 메시지 알림</string>
+    <string name="notification_channel_chat_description" translatable="false">새 메시지가 오면 알림을 받습니다. 중요도를 변경할 경우 배달메이트에서 설정한 알림을 정상적으로 받아보지 못할 수 있습니다.</string>
+    <string name="notification_channel_recruit_id" translatable="false">recruit</string>
+    <string name="notification_channel_recruit_name" translatable="false">모집글 알림</string>
+    <string name="notification_channel_recruit_description" translatable="false">참여하고 있는 모집글의 진행상황에 대한 알림을 받습니다. 중요도를 변경할 경우 배달메이트에서 설정한 알림을 정상적으로 받아보지 못할 수 있습니다.</string>
+    <string name="notification_topic_chat" translatable="false">chat</string>
+    <string name="notification_topic_notice" translatable="false">notice</string>
+    <string name="notification_topic_recruit" translatable="false">recruit</string>
+    <string name="my_page_setting_notification_title_actionbar">알림 설정</string>
+    <string name="my_page_setting_notification_title_all">전체 알림 설정</string>
+    <string name="my_page_setting_notification_description_all">앱에서 보내는 알림을 받아요</string>
+    <string name="my_page_setting_notification_title_new_message">새로운 메시지 알림</string>
+    <string name="my_page_setting_notification_description_new_message">참여한 모집글 채팅방의 새 메시지 알림을 받아요</string>
+    <string name="my_page_setting_notification_title_recruit">모집글 알림</string>
+    <string name="my_page_setting_notification_description_recruit">참여한 모집글 진행상황에 대한 알림을 받아요</string>
+    <string name="my_page_setting_notification_title_notice">공지사항 알림</string>
+    <string name="my_page_setting_notification_description_notice">배달메이트에서 보내는 공지사항 알림을 받아요</string>
+
     <!-- Post Sort -->
     <string name="post_sort_createDate">최신순</string>
     <string name="post_sort_deadlineDate">마감순</string>


### PR DESCRIPTION
## 내용 및 작업사항
### AndroidManifeset
- Android API Level 33에 의한 POST_NOTIFICATION 권한 추가
- FirebaseMessagingService 등록
- FCM default icon, background color, channel id 등록
- FCM Token에 대한 수동 설정을 위해 `auto_init, collection enable` `false` 처리
### FirebaseMessagingService
- FCM 메시지 커스텀을 위한 onMessageReceived override
   - 받아온 remoteMessage 객체에 대해 title, body, image, chatRoomId, notificationType을 파싱 및 notificationType에 따라 Channel 분기처리할 수 있도록 구현
   - 기본적으로 data 필드만 사용하나, notification이 사용되는 경우에 대비해 구현처리. notification과 data이 동시에 있는 경우 data 필드만 처리되도록 구현
   - 알림 클릭시, PendingIntent로 해당 알림에 대한 chatRoomId를 설정해 해당 채팅방으로 이동할 수 있도록 구현
      - MainActivity에서 해당 Intent가 존재하면 바로 해당 채팅방으로 이동하도록 구현
- FCM Token에 대해 register및 unregister 등록 처리 구현
   - register하는 경우 AutoInitEnabled true처리 및 내부 tokenDataStore에 해당 FCM Token 값을 저장하도록 처리
- 공지사항에 대해서만 Topic처리하여 subscribe/unsubscribe처리 할 수 있도록 구현
### Notification API
- 알림 목록을 받아오는 API 네트워크 관련 코드 구현
### Notification Setting
- 알림에 대해 전체 알림 및 그에 대한 하위알림을 3가지인 새메시지 알림, 모집글 관련 알림, 공지사항 알림으로 세부화
- 기존 알림 설정을 시스템 설정으로 이동시켰던 것을 알림 설정 세부 페이지로 이동해 설정할 수 있도록 관련 레이아웃 구현 및 마이페이지 레이아웃 일부 수정
- Notification 세부설정을 저장하는 DataStore 내부에 저장 관련 코드 구현
- 로그인 후 나오는 MainActivity에서 알림 권한 요청을 할 수 있도록 처리 및 최초 허용시에 모든 알림에 대해 허용 처리되도록 설정
- MainActivity를 실행할 때마다 (로그인 직후) FCM Token과 SSAID를 서버에 등록하도록 설정
### Notification Fragment
- 알림 목록 Fragment에서 알림 목록을 받아오기 전에 목록을 받아올 때 까지 Loading 아이콘을 보여주도록 구현

## 참고
- resolved: #214