### PR TITLE
#224 [layout] Change ChatFragment action bar layout

### DIFF
--- a/app/src/main/java/com/mate/baedalmate/data/datasource/remote/chat/ChatResponse.kt
+++ b/app/src/main/java/com/mate/baedalmate/data/datasource/remote/chat/ChatResponse.kt
@@ -50,7 +50,7 @@ data class ChatRoomRecruitDetailDto(
     @SerializedName("deadlineDate")
     val deadlineDate: String,
     @SerializedName("deactivateDate")
-    val deactivateDate: String,
+    val deactivateDate: String?,
     @SerializedName("active")
     val active: Boolean,
     @SerializedName("cancel")

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -96,42 +96,46 @@
                 app:layout_constraintStart_toEndOf="@id/img_chat_info"
                 app:layout_constraintTop_toTopOf="parent">
 
-                <TextView
-                    android:id="@+id/tv_chat_info_contents_created_date"
-                    style="@style/style_body2_kor"
-                    android:layout_width="wrap_content"
+                <LinearLayout
+                    android:id="@+id/layout_chat_info_contents_title"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:textColor="@color/gray_main_C4C4C4"
+                    android:layout_marginEnd="12dp"
+                    android:orientation="horizontal"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintVertical_bias="0.0"
-                    tools:text="2022년 3얼 5일 18시 34분 " />
+                    app:layout_constraintVertical_bias="0.0">
 
-                <TextView
-                    android:id="@+id/tv_chat_info_contents_title"
-                    style="@style/style_semi_title_kor"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="0.0"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_chat_info_contents_created_date"
-                    app:layout_constraintVertical_bias="0.0"
-                    tools:text="피자헛 같이 부술 사람 구합니다" />
+                    <TextView
+                        android:id="@+id/tv_chat_info_contents_title_status"
+                        style="@style/style_semi_title_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/main_FB5F1C"
+                        tools:text="[모집완료]" />
+
+                    <TextView
+                        android:id="@+id/tv_chat_info_contents_title"
+                        style="@style/style_semi_title_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="6dp"
+                        android:singleLine="true"
+                        tools:text="피자헛 같이 부술 사람 구합니다" />
+                </LinearLayout>
 
                 <LinearLayout
                     android:id="@+id/layout_chat_info_contents_criterion"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="6dp"
+                    android:layout_marginEnd="12dp"
                     android:orientation="horizontal"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_chat_info_contents_title"
+                    app:layout_constraintTop_toBottomOf="@id/layout_chat_info_contents_title"
                     app:layout_constraintVertical_bias="0.0">
 
                     <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,6 +247,10 @@
     <string name="chat_list_actionbar_title">채팅방 리스트</string>
 
     <!-- Chat -->
+    <string name="chat_room_status_active">모집중</string>
+    <string name="chat_room_status_fail">모집실패</string>
+    <string name="chat_room_status_cancel">모집취소</string>
+    <string name="chat_room_status_complete">모집완료</string>
     <string name="chat_actionbar_title">채팅방</string>
     <string name="chat_info_action_change_menu">메뉴변경</string>
     <string name="chat_info_action_change_review">후기 작성하기</string>


### PR DESCRIPTION
## 내용및 작업사항
- 채팅방 페이지 상단 액션바 레이아웃 변경에 따라 수정
   - 액션바에 모집글 생성 시간대신 현재 모집글의 상태 (모집중, 모집취소, 모집실패, 모집완료)를 보여줄 수 있도록 구현
- 모집글 모집 마감후 3시간뒤부터 채팅을 입력할 수 없도록 block하는 기능을 구현하던 중 모집이 마감되지 않은 경우 deactivateDate가 null인 상황에 대한 처리가 되어있지 않은 버그 수정
- 채팅방 상단 액션바 영역 클릭시 해당 모집글로 이동할 수 있는 기능 추가
- 모집이 성공했더라도 참여자가 주최자 혼자인 경우엔 리뷰 작성하기 버튼이 비활성화 되도록 처리

## 참고
- resolved: #224