### PR TITLE
#234 [bug] Camera and gallery not available in Android sdk 33

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA"/>

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/profile/MyProfileChangeFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/profile/MyProfileChangeFragment.kt
@@ -52,7 +52,7 @@ class MyProfileChangeFragment : Fragment() {
     private lateinit var glideRequestManager: RequestManager
     private lateinit var loadingAlertDialog: AlertDialog
 
-    private lateinit var userProfileImageString: String
+    private var userProfileImageString: String?= null
     private lateinit var userProfileImageExtension: String
     private val imageFileTimeFormat = SimpleDateFormat("yyyy-MM-d-HH-mm-ss", Locale.KOREA)
     private var imagePath: String? = null
@@ -125,12 +125,12 @@ class MyProfileChangeFragment : Fragment() {
         findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<String>("userProfileImageString")
             ?.observe(viewLifecycleOwner) {
                 userProfileImageString = it
-                if (this::userProfileImageString.isInitialized) {
+                this.userProfileImageString?.let { imageString ->
                     if (userProfileImageString == "resetMyProfileImage") {
                         glideRequestManager.load(R.drawable.ic_person)
                             .centerCrop().into(binding.imgMyProfileChangePhotoThumbnail)
                     } else {
-                        glideRequestManager.load(userProfileImageString.toUri()).centerCrop()
+                        glideRequestManager.load(imageString.toUri()).centerCrop()
                             .into(binding.imgMyProfileChangePhotoThumbnail)
                     }
                 }
@@ -191,11 +191,11 @@ class MyProfileChangeFragment : Fragment() {
     }
 
     private fun getMyProfileImageFile(): File? {
-        return if (userProfileImageString == "resetMyProfileImage") {
+        return if ( userProfileImageString.isNullOrEmpty() || userProfileImageString == "resetMyProfileImage") {
             null
         } else {
             setUploadImagePath(userProfileImageExtension)
-            val originalBitmap = userProfileImageString.toUri().toBitmap()
+            val originalBitmap = userProfileImageString!!.toUri().toBitmap()
             bitmapToFile(originalBitmap, imagePath)
         }
     }

--- a/app/src/main/java/com/mate/baedalmate/presentation/fragment/setAccount/SetAccountMyProfileImageOptionFragment.kt
+++ b/app/src/main/java/com/mate/baedalmate/presentation/fragment/setAccount/SetAccountMyProfileImageOptionFragment.kt
@@ -9,18 +9,22 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
+import android.provider.Settings
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
 import android.view.WindowManager
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
+import androidx.core.app.ActivityCompat
 import androidx.core.content.FileProvider
 import androidx.fragment.app.DialogFragment
 import androidx.navigation.fragment.findNavController
 import com.mate.baedalmate.BuildConfig
+import com.mate.baedalmate.R
 import com.mate.baedalmate.common.GetDeviceSize
 import com.mate.baedalmate.common.autoCleared
 import com.mate.baedalmate.common.extension.setOnDebounceClickListener
@@ -73,35 +77,58 @@ class SetAccountMyProfileImageOptionFragment : DialogFragment() {
 
     private fun setCameraClickListener() {
         binding.layoutSetAccountMyProfileChangeOptionSelectCamera.setOnDebounceClickListener {
-            requestOpenCamera.launch(
-                arrayOf(
-                    Manifest.permission.CAMERA,
-                    Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-                )
-            )
+            requestOpenCamera.launch(PERMISSIONS_CAMERA)
         }
     }
 
     private fun setGalleryClickListener() {
         binding.layoutSetAccountMyProfileChangeOptionSelectGallery.setOnDebounceClickListener {
-            requestOpenGallery.launch(
-                arrayOf(
-                    Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-                )
-            )
+            requestOpenGallery.launch(PERMISSIONS_GALLERY)
         }
     }
 
     private val requestOpenCamera =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-            permissions.entries.forEach {
-                if (it.value == false) {
-                    return@registerForActivityResult
+            val deniedList: List<String> = permissions.filter { !it.value }.map { it.key }
+
+            when {
+                deniedList.isNotEmpty() -> {
+                    val map = deniedList.groupBy { permission ->
+                        if (shouldShowRequestPermissionRationale(permission)) getString(R.string.permission_fail_second)
+                        else getString(R.string.permission_fail_final)
+                    }
+                    map[getString(R.string.permission_fail_second)]?.let {
+                        // request denied , request again
+                        Toast.makeText(
+                            requireContext(),
+                            getString(R.string.permission_fail_message_camera),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        ActivityCompat.requestPermissions(
+                            requireActivity(),
+                            PERMISSIONS_CAMERA,
+                            1000
+                        )
+                    }
+                    map[getString(R.string.permission_fail_final)]?.let {
+                        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).also {
+                            val uri = Uri.parse("package:${requireContext().packageName}")
+                            it.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                            it.data = uri
+                        }
+                        Toast.makeText(
+                            requireContext(),
+                            getString(R.string.permission_fail_final_message_camera),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        //request denied ,send to settings
+                    }
+                }
+                else -> {
+                    //All request are permitted
+                    openCamera()
                 }
             }
-            openCamera()
         }
 
     private fun openCamera() {
@@ -133,12 +160,50 @@ class SetAccountMyProfileImageOptionFragment : DialogFragment() {
 
     private val requestOpenGallery =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-            permissions.entries.forEach {
-                if (it.value == false) {
-                    return@registerForActivityResult
+            val deniedList: List<String> = permissions.filter {
+                !it.value
+            }.map {
+                it.key
+            }
+
+            when {
+                deniedList.isNotEmpty() -> {
+                    val map = deniedList.groupBy { permission ->
+                        if (shouldShowRequestPermissionRationale(permission)) getString(R.string.permission_fail_second)
+                        else getString(R.string.permission_fail_final)
+                    }
+                    map[getString(R.string.permission_fail_second)]?.let {
+                        // request denied , request again
+                        Toast.makeText(
+                            requireContext(),
+                            getString(R.string.permission_fail_message_gallery),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        ActivityCompat.requestPermissions(
+                            requireActivity(),
+                            PERMISSIONS_GALLERY,
+                            1000
+                        )
+                    }
+                    map[getString(R.string.permission_fail_final)]?.let {
+                        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).also {
+                            val uri = Uri.parse("package:${requireContext().packageName}")
+                            it.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                            it.data = uri
+                        }
+                        Toast.makeText(
+                            requireContext(),
+                            getString(R.string.permission_fail_final_message_gallery),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        //request denied ,send to settings
+                    }
+                }
+                else -> {
+                    //All request are permitted
+                    openGallery()
                 }
             }
-            openGallery()
         }
 
     private fun openGallery() {
@@ -187,5 +252,32 @@ class SetAccountMyProfileImageOptionFragment : DialogFragment() {
             fileExtension
         )
         findNavController().popBackStack()
+    }
+
+    companion object {
+        val PERMISSIONS_CAMERA = if (Build.VERSION.SDK_INT >= 33) {
+            arrayOf(
+                Manifest.permission.CAMERA,
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.READ_MEDIA_VIDEO
+            )
+        } else {
+            arrayOf(
+                Manifest.permission.CAMERA,
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+        }
+        val PERMISSIONS_GALLERY = if (Build.VERSION.SDK_INT >= 33) {
+            arrayOf(
+                Manifest.permission.READ_MEDIA_IMAGES,
+                Manifest.permission.READ_MEDIA_VIDEO
+            )
+        } else {
+            arrayOf(
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,14 @@
     <string name="category_asia">아시안</string>
     <string name="category_packedmeal">도시락</string>
 
+    <!-- Device Permission -->
+    <string name="permission_fail_message_camera">카메라 권한을 허용하지 않으면 사진을 등록할 수 없습니다</string>
+    <string name="permission_fail_final_message_camera">카메라를 통해 사진을 등록하려면 설정에서 카메라 권한을 허용으로 변경해주세요</string>
+    <string name="permission_fail_message_gallery">파일 권한을 허용하지 않으면 사진을 등록할 수 없습니다</string>
+    <string name="permission_fail_final_message_gallery">갤러리를 통해 사진을 등록하려면 설정에서 파일 권한을 허용으로 변경해주세요</string>
+    <string name="permission_fail_second">DENIED</string>
+    <string name="permission_fail_final">EXPLAINED</string>
+
     <!-- Select Photo method -->
     <string name="select_photo_method_take_photo">카메라로 찍기</string>
     <string name="select_photo_method_gallery">앨범에서 선택</string>


### PR DESCRIPTION
## 내용및 작업사항
### 기존 문제
- targetSDK를 기존 32에서 33으로 변경 후 카메라 및 갤러리 앱 연동이 불가능한 문제
### 작업 사항
- 요청 권한 내용이 SDK 33에서 변경됨에 따라 33이전과 그 이후를 분기처리해 33 이전에는 동일하게 권한 요청이 이루어 질 수 있도록 하고, 이후에는 새롭게 도입된 미디어 권한으로 요청할 수 있도록 구현
- 기존 유저 프로필 변경시, ImageString이 null로 처리됨에 따라 발생되는 오류에 대해 관련 코드 null-safe 처리

## 참고
- resolved: #234