### PR TITLE
Reflect feature,layout modifications and Fix Bugs in Post Fragment, DIalogs

### DIFF
--- a/app/src/main/res/drawable/selector_btn_gray_line_white_radius_10.xml
+++ b/app/src/main/res/drawable/selector_btn_gray_line_white_radius_10.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gray_line_EBEBEB" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gray_line_EBEBEB" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gray_line_EBEBEB" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+    <item android:state_checked="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/gray_line_EBEBEB" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+    <item android:state_checked="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white_FFFFFF" />
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/selector_btn_pressed_stroke_line_orange_white_main_radius_20.xml
+++ b/app/src/main/res/drawable/selector_btn_pressed_stroke_line_orange_white_main_radius_20.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="20dp" />
+            <solid android:color="@color/main_FB5F1C" />
+            <stroke android:width="1dp" android:color="@color/main_FB5F1C" />
+        </shape>
+    </item>
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="20dp" />
+            <solid android:color="@color/main_FB5F1C" />
+            <stroke android:width="1dp" android:color="@color/main_FB5F1C" />
+        </shape>
+    </item>
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="20dp" />
+            <solid android:color="@color/main_FB5F1C" />
+            <stroke android:width="1dp" android:color="@color/main_FB5F1C" />
+        </shape>
+    </item>
+    <item android:state_checked="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="20dp" />
+            <solid android:color="@color/main_FB5F1C" />
+            <stroke android:width="1dp" android:color="@color/main_FB5F1C" />
+        </shape>
+    </item>
+    <item android:state_checked="false">
+        <shape android:shape="rectangle">
+            <corners android:radius="20dp" />
+            <solid android:color="@color/white_FFFFFF" />
+            <stroke android:width="1dp" android:color="@color/line_orange_FFA077" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/selector_textview_pressed_line_orange_white.xml
+++ b/app/src/main/res/drawable/selector_textview_pressed_line_orange_white.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/white_FFFFFF" android:state_pressed="true" />
+    <item android:color="@color/white_FFFFFF" android:state_selected="true" />
+    <item android:color="@color/white_FFFFFF" android:state_focused="true" />
+    <item android:color="@color/white_FFFFFF" android:state_checked="true" />
+    <item android:color="@color/line_orange_FFA077" android:state_checked="false" />
+</selector>

--- a/app/src/main/res/layout/fragment_post.xml
+++ b/app/src/main/res/layout/fragment_post.xml
@@ -6,7 +6,8 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="@color/white_FFFFFF">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_post_actionbar"
@@ -117,22 +118,6 @@
                         app:shapeAppearanceOverlay="@style/roundImageView"
                         app:strokeColor="@color/white_FFFFFF"
                         app:strokeWidth="2dp" />
-
-                    <com.google.android.material.imageview.ShapeableImageView
-                        android:id="@+id/img_post_back_store"
-                        android:layout_width="36dp"
-                        android:layout_height="36dp"
-                        android:layout_marginTop="-26dp"
-                        android:layout_marginEnd="-26dp"
-                        android:adjustViewBounds="true"
-                        android:background="@color/white_FFFFFF"
-                        android:scaleType="center"
-                        android:src="@drawable/ic_store_map"
-                        app:layout_constraintEnd_toStartOf="@id/img_post_back_delivery_platform"
-                        app:layout_constraintHorizontal_bias="0.0"
-                        app:layout_constraintTop_toBottomOf="@id/img_post_back_delivery_platform"
-                        app:layout_constraintVertical_bias="0.0"
-                        app:shapeAppearanceOverlay="@style/roundImageView" />
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <androidx.constraintlayout.widget.ConstraintLayout
@@ -244,9 +229,8 @@
                         app:layout_constraintTop_toBottomOf="@id/layout_post_front_user"
                         app:layout_constraintVertical_bias="0.0">
 
-                        <TextView
-                            android:id="@+id/tv_post_front_contents_title"
-                            style="@style/style_large_title_kor"
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:id="@+id/layout_post_front_contents_title"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             app:layout_constraintBottom_toBottomOf="parent"
@@ -254,8 +238,47 @@
                             app:layout_constraintHorizontal_bias="0.0"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent"
-                            app:layout_constraintVertical_bias="0.0"
-                            tools:text="유기택 피자 중랑구점" />
+                            app:layout_constraintVertical_bias="0.0">
+
+                            <TextView
+                                android:id="@+id/tv_post_front_contents_title"
+                                style="@style/style_large_title_kor"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginEnd="10dp"
+                                android:singleLine="true"
+                                app:layout_constrainedWidth="true"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toStartOf="@id/view_post_front_contents_close"
+                                app:layout_constraintHorizontal_bias="0.0"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent"
+                                app:layout_constraintVertical_bias="0.0"
+                                tools:text="유기택 피자 중랑구점" />
+
+                            <TextView
+                                android:id="@+id/view_post_front_contents_close"
+                                style="@style/style_caption1_kor"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center"
+                                android:layout_marginStart="8dp"
+                                android:background="@drawable/background_white_radius_20_line_main_gray_stroke_1"
+                                android:minWidth="0dp"
+                                android:minHeight="0dp"
+                                android:paddingHorizontal="7dp"
+                                android:paddingVertical="4dp"
+                                android:stateListAnimator="@null"
+                                android:text="@string/participate_close_2"
+                                android:textColor="@color/gray_main_C4C4C4"
+                                app:layout_constrainedWidth="true"
+                                app:layout_constraintBottom_toBottomOf="@id/tv_post_front_contents_title"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintHorizontal_bias="0.0"
+                                app:layout_constraintTop_toTopOf="@id/tv_post_front_contents_title"
+                                app:layout_constraintVertical_bias="0.5"
+                                app:layout_constraintWidth_min="wrap" />
+                        </androidx.constraintlayout.widget.ConstraintLayout>
 
                         <androidx.constraintlayout.widget.ConstraintLayout
                             android:id="@+id/layout_post_front_contents_deadline"
@@ -266,7 +289,7 @@
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintHorizontal_bias="0.0"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/tv_post_front_contents_title"
+                            app:layout_constraintTop_toBottomOf="@id/layout_post_front_contents_title"
                             app:layout_constraintVertical_bias="0.0">
 
                             <View
@@ -340,14 +363,6 @@
                                         android:layout_height="wrap_content"
                                         android:text="@string/post_deadline_delivery_fee_title"
                                         android:textColor="@color/gray_dark_666666" />
-
-                                    <ImageButton
-                                        android:id="@+id/btn_post_front_contents_deadline_delivery_fee_help"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:layout_marginStart="3dp"
-                                        android:background="@android:color/transparent"
-                                        android:src="@drawable/ic_question_mark_gray_circle" />
                                 </LinearLayout>
 
                                 <TextView
@@ -438,7 +453,7 @@
                         </androidx.constraintlayout.widget.ConstraintLayout>
 
                         <androidx.constraintlayout.widget.ConstraintLayout
-                            android:id="@+id/layout_post_front_contents_detail"
+                            android:id="@+id/layout_post_front_contents_info"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             app:layout_constraintBottom_toBottomOf="parent"
@@ -448,70 +463,180 @@
                             app:layout_constraintTop_toBottomOf="@id/layout_post_front_contents_deadline"
                             app:layout_constraintVertical_bias="0.0">
 
-                            <TextView
-                                android:id="@+id/tv_post_front_contents_detail_title"
-                                style="@style/style_title2_kor"
-                                android:layout_width="0dp"
+                            <androidx.constraintlayout.widget.ConstraintLayout
+                                android:id="@+id/layout_post_front_contents_info_store"
+                                android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:layout_marginTop="15dp"
-                                android:singleLine="true"
-                                android:text="@string/post_detail_title"
-                                android:textColor="@color/main_FB5F1C"
                                 app:layout_constraintBottom_toBottomOf="parent"
-                                app:layout_constraintEnd_toStartOf="@id/tv_post_front_contents_detail_modify"
+                                app:layout_constraintEnd_toEndOf="parent"
                                 app:layout_constraintHorizontal_bias="0.0"
                                 app:layout_constraintStart_toStartOf="parent"
                                 app:layout_constraintTop_toTopOf="parent"
-                                app:layout_constraintVertical_bias="0.0" />
+                                app:layout_constraintVertical_bias="0.0">
 
-                            <TextView
-                                android:id="@+id/tv_post_front_contents_detail_modify"
-                                style="@style/style_body2_kor"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/post_modify"
-                                android:textColor="@color/gray_dark_666666"
-                                android:visibility="gone"
-                                app:layout_constraintBottom_toBottomOf="@id/tv_post_front_contents_detail_title"
-                                app:layout_constraintEnd_toEndOf="parent"
-                                app:layout_constraintHorizontal_bias="1.0"
-                                app:layout_constraintTop_toTopOf="@id/tv_post_front_contents_detail_title"
-                                app:layout_constraintVertical_bias="0.0"
-                                tools:visibility="visible" />
+                                <TextView
+                                    android:id="@+id/tv_post_front_contents_info_store_title"
+                                    style="@style/style_title2_kor"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="15dp"
+                                    android:singleLine="true"
+                                    android:text="@string/post_store_title"
+                                    android:textColor="@color/main_FB5F1C"
+                                    app:layout_constraintBottom_toBottomOf="parent"
+                                    app:layout_constraintEnd_toStartOf="@id/tv_post_front_contents_detail_modify"
+                                    app:layout_constraintHorizontal_bias="0.0"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent"
+                                    app:layout_constraintVertical_bias="0.0" />
 
-                            <TextView
-                                android:id="@+id/tv_post_front_contents_detail"
-                                style="@style/style_body1_kor"
-                                android:layout_width="wrap_content"
+                                <androidx.appcompat.widget.AppCompatButton
+                                    android:id="@+id/btn_post_front_contents_info_store_location"
+                                    style="@style/style_semi_title_kor"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center"
+                                    android:layout_marginStart="8dp"
+                                    android:background="@drawable/selector_btn_pressed_stroke_line_orange_white_main_radius_20"
+                                    android:minWidth="0dp"
+                                    android:minHeight="0dp"
+                                    android:paddingHorizontal="7dp"
+                                    android:paddingVertical="4dp"
+                                    android:stateListAnimator="@null"
+                                    android:text="@string/post_store_location_map"
+                                    android:textColor="@drawable/selector_textview_pressed_line_orange_white"
+                                    app:layout_constraintBottom_toBottomOf="@id/tv_post_front_contents_info_store_title"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintHorizontal_bias="0.0"
+                                    app:layout_constraintStart_toEndOf="@id/tv_post_front_contents_info_store_title"
+                                    app:layout_constraintTop_toTopOf="@id/tv_post_front_contents_info_store_title"
+                                    app:layout_constraintVertical_bias="0.5" />
+
+                                <TextView
+                                    android:id="@+id/tv_post_front_contents_detail_modify"
+                                    style="@style/style_body2_kor"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/post_modify"
+                                    android:textColor="@color/gray_dark_666666"
+                                    android:visibility="gone"
+                                    app:layout_constraintBottom_toBottomOf="@id/tv_post_front_contents_info_store_title"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintHorizontal_bias="1.0"
+                                    app:layout_constraintTop_toTopOf="@id/tv_post_front_contents_info_store_title"
+                                    app:layout_constraintVertical_bias="0.0"
+                                    tools:visibility="visible" />
+
+                                <TextView
+                                    android:id="@+id/tv_post_front_contents_info_store_description"
+                                    style="@style/style_body2_kor"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="13dp"
+                                    android:singleLine="true"
+                                    android:textColor="@color/gray_dark_666666"
+                                    app:layout_constraintBottom_toBottomOf="parent"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintHorizontal_bias="0.0"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toBottomOf="@id/tv_post_front_contents_info_store_title"
+                                    app:layout_constraintVertical_bias="0.0"
+                                    tools:text="유기택 피자 중랑구점" />
+                            </androidx.constraintlayout.widget.ConstraintLayout>
+
+                            <androidx.constraintlayout.widget.ConstraintLayout
+                                android:id="@+id/layout_post_front_contents_info_detail"
+                                android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:layout_marginTop="16dp"
-                                android:paddingBottom="30dp"
-                                android:textColor="@color/black_000000"
+                                android:layout_marginTop="20dp"
                                 app:layout_constraintBottom_toBottomOf="parent"
                                 app:layout_constraintEnd_toEndOf="parent"
                                 app:layout_constraintHorizontal_bias="0.0"
                                 app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintTop_toBottomOf="@id/tv_post_front_contents_detail_title"
-                                app:layout_constraintVertical_bias="0.0"
-                                tools:text="글에 대한 내용이 적힐 부분입니다. 글에 대한 내용이 적힐 부분입니다. 글에 대한 내용이 적힐 부분입니다. 글에 대한 내용이 적힐 부분입니다. 글에 대한 내용이 적힐 부분입니다. " />
+                                app:layout_constraintTop_toBottomOf="@id/layout_post_front_contents_info_store"
+                                app:layout_constraintVertical_bias="0.0">
+
+                                <TextView
+                                    android:id="@+id/tv_post_front_contents_info_detail_title"
+                                    style="@style/style_title2_kor"
+                                    android:layout_width="0dp"
+                                    android:layout_height="wrap_content"
+                                    android:singleLine="true"
+                                    android:text="@string/post_detail_title"
+                                    android:textColor="@color/main_FB5F1C"
+                                    app:layout_constraintBottom_toBottomOf="parent"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintHorizontal_bias="0.0"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent"
+                                    app:layout_constraintVertical_bias="0.0" />
+
+                                <TextView
+                                    android:id="@+id/tv_post_front_contents_info_detail_description"
+                                    style="@style/style_body1_kor"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="16dp"
+                                    android:textColor="@color/black_000000"
+                                    app:layout_constraintBottom_toBottomOf="parent"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintHorizontal_bias="0.0"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toBottomOf="@id/tv_post_front_contents_info_detail_title"
+                                    app:layout_constraintVertical_bias="0.0"
+                                    tools:text="글에 대한 내용이 적힐 부분입니다. 글에 대한 내용이 적힐 부분입니다. 글에 대한 내용이 적힐 부분입니다. 글에 대한 내용이 적힐 부분입니다. 글에 대한 내용이 적힐 부분입니다. " />
+                            </androidx.constraintlayout.widget.ConstraintLayout>
+
+                            <androidx.constraintlayout.widget.ConstraintLayout
+                                android:id="@+id/layout_post_front_contents_info_tag"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="12dp"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintHorizontal_bias="0.0"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toBottomOf="@id/layout_post_front_contents_info_detail"
+                                app:layout_constraintVertical_bias="0.0">
+
+                                <com.google.android.flexbox.FlexboxLayout
+                                    android:id="@+id/layout_post_front_contents_info_tag_list"
+                                    android:layout_width="0dp"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="21dp"
+                                    app:alignContent="stretch"
+                                    app:alignItems="stretch"
+                                    app:flexWrap="wrap"
+                                    app:layout_constraintBottom_toBottomOf="parent"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent">
+
+                                    <com.google.android.material.chip.ChipGroup
+                                        android:id="@+id/chipgroup_post_front_contents_info_tag_list"
+                                        android:layout_width="match_parent"
+                                        android:layout_height="match_parent" />
+                                </com.google.android.flexbox.FlexboxLayout>
+                            </androidx.constraintlayout.widget.ConstraintLayout>
                         </androidx.constraintlayout.widget.ConstraintLayout>
 
                         <androidx.constraintlayout.widget.ConstraintLayout
                             android:id="@+id/layout_post_front_contents_participate"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:layout_marginTop="25dp"
+                            android:layout_marginBottom="29dp"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintHorizontal_bias="0.0"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/layout_post_front_contents_detail"
+                            app:layout_constraintTop_toBottomOf="@id/layout_post_front_contents_info"
                             app:layout_constraintVertical_bias="0.0">
 
                             <androidx.appcompat.widget.AppCompatButton
-                                android:id="@+id/btn_post_front_contents_participate_guest"
+                                android:id="@+id/btn_post_front_contents_participate_one_button"
                                 style="@style/style_button_title_kor"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:layout_marginBottom="62dp"
                                 android:background="@drawable/selector_btn_main_orange_gray_light_radius_10"
                                 android:enabled="false"
                                 android:paddingVertical="14.5dp"
@@ -525,7 +650,7 @@
                                 app:layout_constraintVertical_bias="0.0" />
 
                             <LinearLayout
-                                android:id="@+id/layout_post_front_contents_participate_host"
+                                android:id="@+id/layout_post_front_contents_participate_two_button"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
                                 android:orientation="horizontal"
@@ -535,30 +660,35 @@
                                 app:layout_constraintHorizontal_bias="0.0"
                                 app:layout_constraintStart_toStartOf="parent"
                                 app:layout_constraintTop_toTopOf="parent"
-                                app:layout_constraintVertical_bias="0.0">
+                                app:layout_constraintVertical_bias="0.0"
+                                tools:visibility="visible">
 
                                 <androidx.appcompat.widget.AppCompatButton
-                                    android:id="@+id/btn_post_front_contents_participate_host_cancel"
-                                    style="@style/style_title2_kor"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="match_parent"
+                                    android:id="@+id/btn_post_front_contents_participate_two_button_left"
+                                    style="@style/style_button_title_kor"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_weight="1"
                                     android:background="@drawable/selector_btn_enabled_stroke_orange_line_white_gray_light_radius_10"
                                     android:enabled="false"
+                                    android:paddingVertical="14.5dp"
                                     android:stateListAnimator="@null"
-                                    android:text="@string/post_cancel"
+                                    android:text="채팅방 이동"
                                     android:textColor="@drawable/selector_textview_orange_line_gray_main"
                                     app:layout_constraintBottom_toBottomOf="parent"
                                     app:layout_constraintHorizontal_bias="0.0"
                                     app:layout_constraintStart_toStartOf="parent"
                                     app:layout_constraintTop_toTopOf="parent"
-                                    app:layout_constraintVertical_bias="0.0" />
+                                    app:layout_constraintVertical_bias="0.0"
+                                    tools:enabled="true" />
 
                                 <androidx.appcompat.widget.AppCompatButton
-                                    android:id="@+id/btn_post_front_contents_participate_host_close"
+                                    android:id="@+id/btn_post_front_contents_participate_two_button_right"
                                     style="@style/style_button_title_kor"
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
                                     android:layout_marginStart="10dp"
+                                    android:layout_weight="1"
                                     android:background="@drawable/selector_btn_main_orange_gray_light_radius_10"
                                     android:enabled="false"
                                     android:paddingVertical="14.5dp"
@@ -569,7 +699,8 @@
                                     app:layout_constraintHorizontal_bias="0.0"
                                     app:layout_constraintStart_toStartOf="parent"
                                     app:layout_constraintTop_toTopOf="parent"
-                                    app:layout_constraintVertical_bias="0.0" />
+                                    app:layout_constraintVertical_bias="0.0"
+                                    tools:enabled="true" />
                             </LinearLayout>
                         </androidx.constraintlayout.widget.ConstraintLayout>
                     </androidx.constraintlayout.widget.ConstraintLayout>
@@ -589,7 +720,7 @@
                     app:lottie_loop="true"
                     app:lottie_rawRes="@raw/lottie_loading_post_list"
                     app:lottie_speed="1"
-                    tools:visibility="gone"/>
+                    tools:visibility="gone" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_post_map.xml
+++ b/app/src/main/res/layout/fragment_post_map.xml
@@ -43,6 +43,8 @@
                 android:layout_height="0dp"
                 android:background="@android:color/transparent"
                 android:paddingHorizontal="20dp"
+                android:paddingVertical="10dp"
+                android:scaleType="centerCrop"
                 android:src="@drawable/ic_sign_x_gray_dark"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_post_menu_bottom_sheet_dialog.xml
+++ b/app/src/main/res/layout/fragment_post_menu_bottom_sheet_dialog.xml
@@ -14,350 +14,372 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/background_white_radius_30_top"
-        android:paddingTop="30dp">
+        android:background="@drawable/background_white_radius_30_top">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_post_menu_input"
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/scrollview_post_menu_bottom_sheet_dialog"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingHorizontal="15dp"
+            android:layout_height="match_parent"
+            android:overScrollMode="never"
+            android:paddingTop="30dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.0">
+            app:layout_constraintTop_toTopOf="parent">
 
-            <TextView
-                android:id="@+id/tv_post_menu_title"
-                style="@style/style_title1_kor"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/post_menu_add_title"
-                android:textColor="@color/main_FB5F1C"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <TextView
-                android:id="@+id/tv_post_menu_description"
-                style="@style/style_body2_kor"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_post_menu_bottom_sheet_dialog"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginTop="8dp"
-                android:lineHeight="24dp"
-                android:text="@string/post_menu_add_description"
-                android:textColor="@color/gray_dark_666666"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_post_menu_title"
-                app:layout_constraintVertical_bias="0.0" />
+                android:layout_height="match_parent">
 
-            <LinearLayout
-                android:id="@+id/layout_post_menu_subject"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:orientation="horizontal"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_post_menu_description"
-                app:layout_constraintVertical_bias="0.0">
-
-                <TextView
-                    android:id="@+id/tv_post_menu_subject_title"
-                    style="@style/style_semi_title_kor"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/menu"
-                    android:textColor="@color/black_000000" />
-
-                <EditText
-                    android:id="@+id/et_post_menu_subject_input"
-                    style="@style/style_body2_kor"
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_post_menu_input"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="30dp"
-                    android:hint="@string/write_fourth_add_menu_subject_input_hint"
-                    android:imeOptions="actionNext"
-                    android:maxLines="1"
-                    android:nextFocusDown="@id/et_post_menu_amount_input"
-                    android:singleLine="true"
-                    android:textColor="@color/black_000000"
-                    android:textColorHint="@color/gray_dark_666666"
-                    android:theme="@style/EditTextBackground" />
-            </LinearLayout>
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/layout_post_menu_amount"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="22dp"
-                android:orientation="horizontal"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layout_post_menu_subject"
-                app:layout_constraintVertical_bias="0.0">
-
-                <TextView
-                    android:id="@+id/tv_post_menu_amount_title"
-                    style="@style/style_semi_title_kor"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/amount"
-                    android:textColor="@color/black_000000"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="0.0"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintVertical_bias="0.5" />
-
-                <View
-                    android:id="@+id/view_post_menu_amount_input_background"
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:layout_marginStart="30dp"
-                    android:background="@drawable/background_white_radius_10_stroke_gray_line"
                     android:paddingHorizontal="15dp"
-                    android:paddingVertical="13dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/tv_post_menu_amount_title"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <TextView
-                    android:id="@+id/tv_post_menu_amount_input_unit"
-                    style="@style/style_title2_kor"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:gravity="end"
-                    android:paddingVertical="13dp"
-                    android:paddingEnd="15dp"
-                    android:text="@string/unit_korea"
-                    android:textColor="@color/black_000000"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="1.0"
-                    app:layout_constraintStart_toEndOf="@id/tv_post_menu_amount_title"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <EditText
-                    android:id="@+id/et_post_menu_amount_input"
-                    style="@style/style_title2_kor"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:background="@android:color/transparent"
-                    android:gravity="end"
-                    android:imeOptions="actionDone"
-                    android:inputType="number"
-                    android:maxLength="9"
-                    android:maxLines="1"
-                    android:paddingVertical="13dp"
-                    android:paddingStart="15dp"
-                    android:textColor="@color/black_000000"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/tv_post_menu_amount_input_unit"
-                    app:layout_constraintHorizontal_bias="1.0"
-                    app:layout_constraintStart_toStartOf="@id/view_post_menu_amount_input_background"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:text="10,000" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/layout_post_menu_count"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="22dp"
-                android:orientation="horizontal"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layout_post_menu_amount"
-                app:layout_constraintVertical_bias="0.0">
-
-                <TextView
-                    android:id="@+id/tv_post_menu_count_title"
-                    style="@style/style_semi_title_kor"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/count"
-                    android:textColor="@color/black_000000"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintVertical_bias="0.5" />
+                    app:layout_constraintVertical_bias="0.0">
 
-                <com.google.android.material.imageview.ShapeableImageView
-                    android:id="@+id/img_post_menu_dish_count_increase"
-                    android:layout_width="30dp"
-                    android:layout_height="30dp"
-                    android:scaleType="center"
-                    android:src="@drawable/ic_plus_gray_dark"
+                    <TextView
+                        android:id="@+id/tv_post_menu_title"
+                        style="@style/style_title1_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/post_menu_add_title"
+                        android:textColor="@color/main_FB5F1C"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.0"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintVertical_bias="0.0" />
+
+                    <TextView
+                        android:id="@+id/tv_post_menu_description"
+                        style="@style/style_body2_kor"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_marginTop="8dp"
+                        android:lineHeight="24dp"
+                        android:text="@string/post_menu_add_description"
+                        android:textColor="@color/gray_dark_666666"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.0"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_post_menu_title"
+                        app:layout_constraintVertical_bias="0.0" />
+
+                    <LinearLayout
+                        android:id="@+id/layout_post_menu_subject"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:orientation="horizontal"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.0"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_post_menu_description"
+                        app:layout_constraintVertical_bias="0.0">
+
+                        <TextView
+                            android:id="@+id/tv_post_menu_subject_title"
+                            style="@style/style_semi_title_kor"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/menu"
+                            android:textColor="@color/black_000000" />
+
+                        <EditText
+                            android:id="@+id/et_post_menu_subject_input"
+                            style="@style/style_body2_kor"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="30dp"
+                            android:hint="@string/write_fourth_add_menu_subject_input_hint"
+                            android:imeOptions="actionNext"
+                            android:maxLines="1"
+                            android:nextFocusDown="@id/et_post_menu_amount_input"
+                            android:singleLine="true"
+                            android:textColor="@color/black_000000"
+                            android:textColorHint="@color/gray_dark_666666"
+                            android:theme="@style/EditTextBackground" />
+                    </LinearLayout>
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/layout_post_menu_amount"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="22dp"
+                        android:orientation="horizontal"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.0"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/layout_post_menu_subject"
+                        app:layout_constraintVertical_bias="0.0">
+
+                        <TextView
+                            android:id="@+id/tv_post_menu_amount_title"
+                            style="@style/style_semi_title_kor"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/amount"
+                            android:textColor="@color/black_000000"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintHorizontal_bias="0.0"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintVertical_bias="0.5" />
+
+                        <View
+                            android:id="@+id/view_post_menu_amount_input_background"
+                            android:layout_width="0dp"
+                            android:layout_height="0dp"
+                            android:layout_marginStart="30dp"
+                            android:background="@drawable/background_white_radius_10_stroke_gray_line"
+                            android:paddingHorizontal="15dp"
+                            android:paddingVertical="13dp"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toEndOf="@id/tv_post_menu_amount_title"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <TextView
+                            android:id="@+id/tv_post_menu_amount_input_unit"
+                            style="@style/style_title2_kor"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:gravity="end"
+                            android:paddingVertical="13dp"
+                            android:paddingEnd="15dp"
+                            android:text="@string/unit_korea"
+                            android:textColor="@color/black_000000"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintHorizontal_bias="1.0"
+                            app:layout_constraintStart_toEndOf="@id/tv_post_menu_amount_title"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <EditText
+                            android:id="@+id/et_post_menu_amount_input"
+                            style="@style/style_title2_kor"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:background="@android:color/transparent"
+                            android:gravity="end"
+                            android:hint="10,000"
+                            android:imeOptions="actionDone"
+                            android:inputType="number"
+                            android:maxLength="9"
+                            android:maxLines="1"
+                            android:paddingVertical="13dp"
+                            android:paddingStart="15dp"
+                            android:textColor="@color/black_000000"
+                            android:textColorHint="@color/gray_main_C4C4C4"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/tv_post_menu_amount_input_unit"
+                            app:layout_constraintHorizontal_bias="1.0"
+                            app:layout_constraintStart_toStartOf="@id/view_post_menu_amount_input_background"
+                            app:layout_constraintTop_toTopOf="parent"
+                            tools:text="10,000" />
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/layout_post_menu_count"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="22dp"
+                        android:orientation="horizontal"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.0"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/layout_post_menu_amount"
+                        app:layout_constraintVertical_bias="0.0">
+
+                        <TextView
+                            android:id="@+id/tv_post_menu_count_title"
+                            style="@style/style_semi_title_kor"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/count"
+                            android:textColor="@color/black_000000"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintHorizontal_bias="0.0"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintVertical_bias="0.5" />
+
+                        <com.google.android.material.imageview.ShapeableImageView
+                            android:id="@+id/img_post_menu_dish_count_increase"
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:scaleType="center"
+                            android:src="@drawable/ic_plus_gray_dark"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintHorizontal_bias="1.0"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintVertical_bias="0.5"
+                            app:shapeAppearanceOverlay="@style/roundImageView"
+                            app:strokeColor="@color/gray_line_EBEBEB"
+                            app:strokeWidth="1dp" />
+
+                        <TextView
+                            android:id="@+id/tv_post_menu_dish_count_current"
+                            style="@style/style_title2_kor"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@{Integer.toString(currentDishCount)+`개`}"
+                            android:textColor="@color/black_000000"
+                            app:layout_constraintBottom_toBottomOf="@id/img_post_menu_dish_count_increase"
+                            app:layout_constraintEnd_toStartOf="@id/img_post_menu_dish_count_increase"
+                            app:layout_constraintHorizontal_bias="0.5"
+                            app:layout_constraintStart_toEndOf="@id/img_post_menu_dish_count_decrease"
+                            app:layout_constraintTop_toTopOf="@id/img_post_menu_dish_count_increase"
+                            app:layout_constraintVertical_bias="0.5"
+                            tools:text="1개" />
+
+                        <com.google.android.material.imageview.ShapeableImageView
+                            android:id="@+id/img_post_menu_dish_count_decrease"
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:layout_marginEnd="105dp"
+                            android:background="#D9D9D9"
+                            android:scaleType="center"
+                            android:src="@drawable/ic_minus_gray_dark"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/img_post_menu_dish_count_increase"
+                            app:layout_constraintHorizontal_bias="1.0"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintVertical_bias="0.5"
+                            app:shapeAppearanceOverlay="@style/roundImageView" />
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    <View
+                        android:id="@+id/view_post_menu_contents_horizontal_line_top"
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_marginTop="15dp"
+                        android:background="@color/gray_line_EBEBEB"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/layout_post_menu_count"
+                        app:layout_constraintVertical_bias="0.0" />
+
+                    <TextView
+                        android:id="@+id/tv_post_menu_add"
+                        style="@style/style_title2_kor"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:enabled="false"
+                        android:gravity="center"
+                        android:paddingTop="16dp"
+                        android:paddingBottom="35dp"
+                        android:text="@string/add_menu"
+                        android:textColor="@color/black_000000"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.5"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/view_post_menu_contents_horizontal_line_top"
+                        app:layout_constraintVertical_bias="0.0" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/layout_post_menu_added"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="28dp"
+                    android:animateLayoutChanges="true"
+                    android:background="@color/background_F7F8FA"
+                    android:paddingTop="15dp"
+                    android:layout_marginHorizontal="15dp"
+                    android:paddingBottom="23dp"
+                    android:visibility="visible"
+                    app:layout_constraintBottom_toTopOf="@id/btn_post_front_contents_participate"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_post_menu_input"
+                    app:layout_constraintVertical_bias="0.0">
+
+                    <TextView
+                        android:id="@+id/tv_post_menu_added_title"
+                        style="@style/style_title1_kor"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/post_menu_added_title"
+                        android:textColor="@color/main_FB5F1C"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.0"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintVertical_bias="0.0" />
+
+                    <HorizontalScrollView
+                        android:id="@+id/layout_scroll_post_menu_added"
+                        android:layout_width="match_parent"
+                        android:layout_height="123dp"
+                        android:layout_marginStart="5dp"
+                        android:scrollbarFadeDuration="0"
+                        android:scrollbarThumbHorizontal="@color/gray_dark_666666"
+                        android:scrollbars="horizontal"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.0"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_post_menu_added_title"
+                        app:layout_constraintVertical_bias="0.0">
+
+                        <RelativeLayout
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:animateLayoutChanges="true">
+
+                            <androidx.recyclerview.widget.RecyclerView
+                                android:id="@+id/rv_post_menu_added_list"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_alignParentLeft="true"
+                                android:layout_centerVertical="true"
+                                android:layout_marginStart="5dp"
+                                android:orientation="horizontal"
+                                tools:listitem="@layout/item_menu_saved" />
+                        </RelativeLayout>
+                    </HorizontalScrollView>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_post_front_contents_participate"
+                    style="@style/style_button_title_kor"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="15dp"
+                    android:layout_marginBottom="12dp"
+                    android:background="@drawable/selector_btn_main_orange_gray_light_radius_10"
+                    android:enabled="false"
+                    android:paddingVertical="14.5dp"
+                    android:stateListAnimator="@null"
+                    android:text="@string/post_participate_in"
+                    android:textColor="@drawable/selector_textview_white_gray_main"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="1.0"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintVertical_bias="0.5"
-                    app:shapeAppearanceOverlay="@style/roundImageView"
-                    app:strokeColor="@color/gray_line_EBEBEB"
-                    app:strokeWidth="1dp" />
-
-                <TextView
-                    android:id="@+id/tv_post_menu_dish_count_current"
-                    style="@style/style_title2_kor"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@{Integer.toString(currentDishCount)+`개`}"
-                    android:textColor="@color/black_000000"
-                    app:layout_constraintBottom_toBottomOf="@id/img_post_menu_dish_count_increase"
-                    app:layout_constraintEnd_toStartOf="@id/img_post_menu_dish_count_increase"
-                    app:layout_constraintHorizontal_bias="0.5"
-                    app:layout_constraintStart_toEndOf="@id/img_post_menu_dish_count_decrease"
-                    app:layout_constraintTop_toTopOf="@id/img_post_menu_dish_count_increase"
-                    app:layout_constraintVertical_bias="0.5"
-                    tools:text="1개" />
-
-                <com.google.android.material.imageview.ShapeableImageView
-                    android:id="@+id/img_post_menu_dish_count_decrease"
-                    android:layout_width="30dp"
-                    android:layout_height="30dp"
-                    android:layout_marginEnd="105dp"
-                    android:background="#D9D9D9"
-                    android:scaleType="center"
-                    android:src="@drawable/ic_minus_gray_dark"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/img_post_menu_dish_count_increase"
-                    app:layout_constraintHorizontal_bias="1.0"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintVertical_bias="0.5"
-                    app:shapeAppearanceOverlay="@style/roundImageView" />
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_post_menu_input"
+                    app:layout_constraintVertical_bias="1.0" />
             </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <View
-                android:id="@+id/view_post_menu_contents_horizontal_line_top"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginTop="15dp"
-                android:background="@color/gray_line_EBEBEB"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layout_post_menu_count"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <TextView
-                android:id="@+id/tv_post_menu_add"
-                style="@style/style_title2_kor"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:enabled="false"
-                android:gravity="center"
-                android:paddingTop="16dp"
-                android:paddingBottom="35dp"
-                android:text="@string/add_menu"
-                android:textColor="@color/black_000000"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/view_post_menu_contents_horizontal_line_top"
-                app:layout_constraintVertical_bias="0.0" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_post_menu_added"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="15dp"
-            android:layout_marginBottom="28dp"
-            android:animateLayoutChanges="true"
-            android:background="@color/background_F7F8FA"
-            android:paddingHorizontal="15dp"
-            android:paddingTop="15dp"
-            android:visibility="visible"
-            app:layout_constraintBottom_toTopOf="@id/btn_post_front_contents_participate"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_post_menu_input"
-            app:layout_constraintVertical_bias="0.0">
-
-            <TextView
-                android:id="@+id/tv_post_menu_added_title"
-                style="@style/style_title1_kor"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/post_menu_added_title"
-                android:textColor="@color/main_FB5F1C"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <HorizontalScrollView
-                android:id="@+id/layout_scroll_post_menu_added"
-                android:layout_width="match_parent"
-                android:layout_height="123dp"
-                android:layout_marginTop="15dp"
-                android:overScrollMode="never"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_post_menu_added_title"
-                app:layout_constraintVertical_bias="0.0">
-
-                <RelativeLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:animateLayoutChanges="true">
-
-                    <androidx.recyclerview.widget.RecyclerView
-                        android:id="@+id/rv_post_menu_added_list"
-                        android:layout_width="wrap_content"
-                        android:layout_height="90dp"
-                        android:layout_alignParentLeft="true"
-                        android:layout_centerVertical="true"
-                        android:layout_marginStart="15dp"
-                        android:orientation="horizontal" />
-                </RelativeLayout>
-            </HorizontalScrollView>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_post_front_contents_participate"
-            style="@style/style_button_title_kor"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="15dp"
-            android:layout_marginBottom="12dp"
-            android:background="@drawable/selector_btn_main_orange_gray_light_radius_10"
-            android:enabled="false"
-            android:paddingVertical="14.5dp"
-            android:stateListAnimator="@null"
-            android:text="@string/post_participate_in"
-            android:textColor="@drawable/selector_textview_white_gray_main"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_post_menu_input"
-            app:layout_constraintVertical_bias="1.0" />
+        </androidx.core.widget.NestedScrollView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_post_option.xml
+++ b/app/src/main/res/layout/fragment_post_option.xml
@@ -8,64 +8,101 @@
     tools:context=".presentation.fragment.post.PostOptionFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_post_option_select_block"
+        android:id="@+id/layout_post_option_participant"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/selector_btn_gray_line_white_radius_10_top"
-        android:paddingHorizontal="15dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="gone">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_post_option_participant_select_block"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/selector_btn_gray_line_white_radius_10_top"
+            android:enabled="false"
+            android:paddingHorizontal="15dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/tv_post_option_participant_select_block"
+                style="@style/style_body1_kor"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="21dp"
+                android:layout_marginBottom="17dp"
+                android:text="@string/block"
+                android:textColor="@color/black_000000"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <LinearLayout
+            android:id="@+id/layout_post_option_participant_block_report_divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/white_FFFFFF"
+            android:enabled="false"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_post_option_participant_select_block">
+
+            <View
+                android:id="@+id/view_post_option_participant_block_report_divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginHorizontal="10dp"
+                android:background="@color/gray_line_EBEBEB" />
+        </LinearLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_post_option_participant_select_report"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/selector_btn_gray_line_white_radius_10_bottom"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_post_option_participant_block_report_divider">
+
+            <TextView
+                android:id="@+id/tv_post_option_participant_select_report"
+                style="@style/style_body1_kor"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="17dp"
+                android:text="@string/report"
+                android:textColor="@color/black_000000"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_post_option_host_cancel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/selector_btn_gray_line_white_radius_10"
+        android:enabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
-            android:id="@+id/tv_post_option_select_block"
+            android:id="@+id/tv_post_option_host_cancel"
             style="@style/style_body1_kor"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="21dp"
             android:layout_marginBottom="17dp"
-            android:text="@string/block"
-            android:textColor="@color/black_000000"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <LinearLayout
-        android:id="@+id/layout_post_option_block_report_divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/white_FFFFFF"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/layout_post_option_select_block">
-
-        <View
-            android:id="@+id/view_post_option_block_report_divider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginHorizontal="10dp"
-            android:background="@color/gray_line_EBEBEB" />
-    </LinearLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_post_option_select_report"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@drawable/selector_btn_gray_line_white_radius_10_bottom"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/layout_post_option_block_report_divider">
-
-        <TextView
-            android:id="@+id/tv_post_option_select_report"
-            style="@style/style_body1_kor"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginVertical="17dp"
-            android:text="@string/report"
+            android:text="@string/post_cancel"
             android:textColor="@color/black_000000"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -143,6 +143,14 @@
         <action
             android:id="@+id/action_postFragment_to_postOptionFragment"
             app:destination="@+id/PostOptionFragment" />
+
+        <action
+            android:id="@+id/action_postFragment_to_chatFragment"
+            app:destination="@id/ChatFragment"
+            app:enterAnim="@anim/slide_from_right"
+            app:exitAnim="@anim/slide_to_left"
+            app:popEnterAnim="@anim/slide_from_left"
+            app:popExitAnim="@anim/slide_to_right" />
     </fragment>
 
     <dialog
@@ -150,6 +158,10 @@
         android:name="com.mate.baedalmate.presentation.fragment.post.PostOptionFragment"
         android:label="fragment_post_option"
         tools:layout="@layout/fragment_post_option">
+        <argument
+            android:name="isHost"
+            android:defaultValue="false"
+            app:argType="boolean" />
         <argument
             android:name="postId"
             android:defaultValue="0"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,8 +185,8 @@
     <string name="post_alert_message_close">해당 모집글이 마감처리 되었습니다</string>
     <string name="post_alert_message_cancel">해당 모집글이 취소처리 되었습니다</string>
     <string name="post_alert_message_cancel_participate">참여 취소되었습니다.</string>
-    <string name="post_menu_add_title">주문메뉴 추가</string>
-    <string name="post_menu_add_description">추가할 메뉴와 금액을 작성하여, 모든 메뉴를 추가한 뒤 모집에 참여하세요</string>
+    <string name="post_menu_add_title">주문할 메뉴 추가하기</string>
+    <string name="post_menu_add_description">내가 시키고 싶은 메뉴들의 이름과 각 금액을 작성하고, 모집에 참여하세요!</string>
     <string name="post_menu_added_title">현재 작성 메뉴</string>
     <string name="post_category_list_empty">현재 \'%s\' 에 대한\n모집글이 없어요</string>
     <string name="post_category_list_load_fail">네트워크 통신이 원활하지 않습니다.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,6 @@
     <string name="add">추가하기</string>
     <string name="add_menu">메뉴 추가하기</string>
     <string name="title">제목</string>
-    <string name="user_location">배달 거점</string>
     <string name="store_location">배달 가게</string>
     <string name="delivery_platform">배달 플랫폼</string>
     <string name="confirm">확인</string>
@@ -40,6 +39,7 @@
     <string name="dialog_loading_wait_description">잠시만 기다려 주세요!</string>
     <string name="participate_complete">모집 완료</string>
     <string name="participate_close">모집 마감</string>
+    <string name="participate_close_2">모집마감</string>
     <string name="retry">다시시도</string>
 
     <!-- Notification -->
@@ -159,16 +159,22 @@
 
     <!-- Post -->
     <string name="post_actionbar_title">글 상세 보기</string>
+    <string name="user_score_format">%.1f</string>
     <string name="post_deadline_time_title">마감시간</string>
+    <string name="post_deadline_time_format">%s시 %s분</string>
     <string name="post_deadline_delivery_fee_title">배달비</string>
     <string name="post_deadline_people_title">모집인원</string>
-    <string name="post_deadline_dormitory_title">배달거점</string>
+    <string name="post_deadline_people_format">%s명 / %s명</string>
+    <string name="post_deadline_dormitory_title">모이는 곳</string>
+    <string name="post_store_title">배달가게</string>
+    <string name="post_store_location_map">지도보기</string>
     <string name="post_detail_title">상세설명</string>
+    <string name="post_navigate_to_chatroom">채팅방 이동</string>
     <string name="post_participate_in">모집 참여하기</string>
     <string name="post_participate_out">모집 나가기</string>
     <string name="post_close">모집 마감하기</string>
     <string name="post_not_active">마감된 모집글입니다</string>
-    <string name="post_cancel">모집 취소</string>
+    <string name="post_cancel">모집 취소하기</string>
     <string name="post_delivery_fee_help_detail_title">배달비 상세정보</string>
     <string name="post_delivery_fee_help_detail_description">해당 모집글의 총 주문금액에 따른 배달팁 구간이 강조되어 표시됩니다.</string>
     <string name="post_delivery_fee_help_detail_free">배달비 없음</string>
@@ -189,6 +195,8 @@
     <string name="post_cancel_dialog_description">모집 취소 시, 지금까지 진행된 모집이 중단됩니다.</string>
     <string name="post_close_dialog_title">모집을 마감하시겠습니까?</string>
     <string name="post_close_dialog_description">모집 마감 시, 다른 참여자들이 해당 모집에 더 이상 참여할 수 없습니다.</string>
+    <string name="post_cancel_participate_dialog_title">참여한 모집글을 나가시겠습니까?</string>
+    <string name="post_cancel_participate_dialog_description">확인 버튼을 누르면 참여한 모집글에서 나가게 됩니다.</string>
 
     <!-- Write -->
     <string name="write_actionbar_title">상세 설정</string>


### PR DESCRIPTION
## 내용 및 작업사항
### PostFragment
- 쿠폰및 배달비 구간 삭제 및 예상 배달비 요소 추가, 배달 거점 워딩 제거 등에 따른 디자인 변경사항 반영
   - 이에따라 쿠폰및 배달비 구간에 대한 상세설명을 제공하던 dialog 및 관련 코드 제거
   - 배달 거점 대신 모이는 곳으로 좀 더 직관적으로 사용자가 모집글 내용을 확인할 수 있도록 변경
   - 모집 마감 표시 추가
- 기존 배달가게를 플랫폼 좌측 하단 지도를 통해서만 확인이 가능했던 사항을 별도의 레이아웃으로 분리해 배달 가게를 표시하도로 구현 및 기존 지도 아이콘 삭제후 지도 보기 버튼 도입
   - 지도 Dialog에서의 닫기버튼 크기 늘림
- 최하단 상황에 따른 액션버튼에 대한 수정
   - 해당 모집글 참여한 상태인 경우에 대한 채팅방 이동 버튼 구현
   - 참여자 및 주최자 구분에 따라 모집 나가기 및 모집 마감하기 버튼 구현, 기존 버튼의 weight가 달랐던 점을 1:1로 변경
   - 기존에 주최자 화면에서 나왔던 모집 취소하기 버튼은 우측 상단 옵션 버튼으로 실행 가능하도록 변경함에 따라 주최자의 경우도 옵션 버튼이 보이도록 설정
      - 마감된 모집글인 경우 취소하기가 불가능하므로, 마감된 경우엔 옵션이 보이지 않도록 조정
- 기존에 주최자의 별점이 소수점 아래자리가 모두 나왔던 것을 소수점 첫째자리까지만 표시할수 있도록 조정

### PostMenuBottomSheetDialog
- 메뉴 추가시 우측으로 메뉴가 추가되던 것을 reverse 시켜 좌측부터 추가되도록 하여 추가된 메뉴가 가장 좌측에 위치하도록 설정
- 메뉴가 추가되는 경우 BottomSheet가 길어짐에 따라 소프트키보드가 표시되면서 BottomSheet를 가리므로, 이를 ScrollView를 도입시켜 소프트 키보드가 나오더라도 스크롤이 가능하도록 설정
- 메뉴 추가및 삭제간 애니메이션 적용

### PostOptionDialog
- 기존 PostFragment에서 존재하던 모집 취소하기를 Option에서 선택가능하도록 추가 

## 참고
- #242 